### PR TITLE
Feature/#32-create section header component

### DIFF
--- a/design_system/src/main/java/com/baghdad/design_system/components/SectionHeader.kt
+++ b/design_system/src/main/java/com/baghdad/design_system/components/SectionHeader.kt
@@ -1,0 +1,62 @@
+package com.baghdad.design_system.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.baghdad.design_system.theme.Theme
+
+@Composable
+fun SectionHeader(
+    title: String,
+    actionText: String,
+    isAllTextVisiable: Boolean,
+    actionIcon: ImageVector,
+    contentDiscription: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 7.dp)
+            .clickable(onClick = onClick),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = title,
+            style = Theme.typography.headline.small
+                .copy(color = Theme.color.title)
+        )
+
+        if (isAllTextVisiable) {
+            Row {
+                Text(
+                    text = actionText,
+                    style = Theme.typography.label.medium
+                        .copy(color = Theme.color.primary)
+                )
+                Icon(
+                    imageVector = actionIcon,
+                    contentDescription = contentDiscription,
+                    tint = Theme.color.primary,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .size(16.dp)
+                )
+            }
+        }
+    }
+}
+
+    


### PR DESCRIPTION
1- Created a reusable SectionHeader composable for section titles 
![figma](https://github.com/user-attachments/assets/76dcbbec-13a1-497e-9cdc-572682a282fd)

![preview](https://github.com/user-attachments/assets/39e69baf-89b2-4fff-8c11-6de5c671b5b7)


Hint : There's a mistake in the Figma design, the arrow appears in a different color by mistake, but it should have the same color as the "All" text.