### PR TITLE
Fix/#209 the recent viewed  lazy row padding and Visability images 

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/component/HorizontalMediaCardList.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/HorizontalMediaCardList.kt
@@ -25,7 +25,6 @@ fun <T> HorizontalMediaCardList(
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 12.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/RecentlyViewedSection.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/RecentlyViewedSection.kt
@@ -31,8 +31,6 @@ fun RecentlyViewedSection(
         onCardClick = { onRecentlyViewedClick(it.id) },
         isSaved = { it.isSaved },
         modifier = Modifier
-            .fillMaxWidth(0.45f)
-            .aspectRatio(0.8f)
             .padding(bottom = 12.dp)
     )
 }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
@@ -405,7 +405,7 @@ class SearchViewModel(
         contentId: Long
     ) {
         val contentImageUrl =
-            currentState.tvShows.find { it.id == contentId }?.posterPictureURL ?: ""
+            currentState.movies.find { it.id == contentId }?.posterPictureURL ?: ""
         tryToExecute(
             callee = {
                 addRecentlyViewedUseCase(


### PR DESCRIPTION
- Fix the padding and full width behavior of the Recently Viewed LazyRow to ensure items take the correct horizontal space.

- Correct how TV Shows are retrieved and displayed in Recently Viewed by fetching the correct image URL source.

https://github.com/user-attachments/assets/e948c270-5620-472a-9d8b-0a99e34f8ccc











