### PR TITLE
Fix:/#225 clear all button to delete the all recent viewed not recent search

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
@@ -157,7 +157,7 @@ private fun RecentlyViewsWithSearch(
                 item {
                     RecentlyViewedSection(
                         recentViewed = uiState.recentViewed,
-                        onClearRecentlyViewedClick = { listener.onClearRecentSearchClick() },
+                        onClearRecentlyViewedClick = { listener.onClearRecentlyViewedClick() },
                         onSavedClick = { listener.onSaveRecentlyViewedClick(it) },
                         onRecentlyViewedClick = { listener.onRecentlyViewedClick(it) },
                         modifier = Modifier.padding(top = 12.dp)


### PR DESCRIPTION
-  Fix Clear all button to delete the all recent viewed not recent search

https://github.com/user-attachments/assets/8fd20567-b8c3-4cf0-847c-6cf3b898b152


Note: The branch with the lazy row width modification hasn't been merged yet, so the card might appear unclear or misaligned, and this is because the branch hasn't been merged.




