### PR TITLE
Fix/#240 ActorDetailsViewModel is always initialized with the same actorId

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
@@ -15,7 +15,10 @@ import org.koin.core.parameter.parametersOf
 @Composable
 fun ActorDetailsScreen(
     actorId: Long,
-    viewModel: ActorDetailsViewModel = koinViewModel(parameters = { parametersOf(actorId) }),
+    viewModel: ActorDetailsViewModel = koinViewModel(
+        key = actorId.toString(),
+        parameters = { parametersOf(actorId) }
+    ),
     handleNavigation: (ActorDetailsNavEvent) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/ui/src/main/java/com/baghdad/ui/feature/actorGallery/GalleryScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/actorGallery/GalleryScreen.kt
@@ -33,7 +33,10 @@ import org.koin.core.parameter.parametersOf
 @Composable
 fun GalleryScreen(
     actorId: Long,
-    viewModel: ActorGalleryViewModel = koinViewModel(parameters = { parametersOf(actorId) }),
+    viewModel: ActorGalleryViewModel = koinViewModel(
+        key = actorId.toString(),
+        parameters = { parametersOf(actorId) }
+    ),
     handleNavigation: (ActorDetailsNavEvent) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -60,7 +63,9 @@ fun ActorGalleryScreenContent(
     uiState: ActorGalleryScreenState,
     listner: ActorGalleryViewModel
 ) {
-    Column(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+    Column(modifier = Modifier
+        .fillMaxSize()
+        .statusBarsPadding()) {
         TopAppBar(
             onGoBackClick = listner::onBackClick,
             screenTitle = stringResource(R.string.gallery),


### PR DESCRIPTION
- Added `actorId` as key to `koinViewModel` in `ActorDetailsScreen` and `ActorGalleryScreen` so that it's always recreated when a new actorId is passed.