### PR TITLE
Feature/#284 initialize retrofit with okhttp custom interceptor and proguard rules

### DIFF
--- a/.github/workflows/NovixCD.yml
+++ b/.github/workflows/NovixCD.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Create secrets.properties file
         run: |
           echo "API_KEY=\"${{ secrets.API_KEY }}\"" > app/secrets.properties
+          echo "BASE_URL=\"https://api.themoviedb.org/3\"" >> app/secrets.properties
 
       - name: Decode keystore
         run: |

--- a/.github/workflows/NovixCI.yml
+++ b/.github/workflows/NovixCI.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Create secrets.properties file
         run: |
           echo "API_KEY=\"${{ secrets.API_KEY }}\"" > app/secrets.properties
+          echo "BASE_URL=\"https://api.themoviedb.org/3\"" >> app/secrets.properties
 
       - name: Decode keystore
         run: |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,11 +32,18 @@ android {
         properties.load(keystoreFile.inputStream())
 
         val apiKey = properties.getProperty("API_KEY") ?: ""
+        val baseUrl = properties.getProperty("BASE_URL") ?: ""
 
         buildConfigField(
             type = "String",
             name = "API_KEY",
             value = apiKey
+        )
+
+        buildConfigField(
+            type = "String",
+            name = "BASE_URL",
+            value = baseUrl
         )
     }
 
@@ -116,7 +123,7 @@ dependencies {
     implementation(libs.bundles.ktor.client)
     testImplementation(libs.bundles.test.core)
     implementation(libs.bundles.room)
-
+    implementation(libs.bundles.retrofit)
 }
 
 /**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -45,3 +45,54 @@
 -dontwarn org.slf4j.impl.StaticMarkerBinder
 -dontwarn org.tensorflow.lite.gpu.GpuDelegateFactory$Options$GpuBackend
 -dontwarn org.tensorflow.lite.gpu.GpuDelegateFactory$Options
+
+
+#Retrofit
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep inherited services.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# R8 full mode strips generic signatures from return types if not kept.
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# With R8 full mode generic signatures are stripped for classes that are not kept.
+-keep,allowobfuscation,allowshrinking class retrofit2.Response

--- a/app/src/main/java/com/baghdad/novix/di/NetworkModule.kt
+++ b/app/src/main/java/com/baghdad/novix/di/NetworkModule.kt
@@ -8,7 +8,8 @@ import com.baghdad.remoteDataSource.RemoteGenreDataSourceImpl
 import com.baghdad.remoteDataSource.RemoteMovieDataSourceImpl
 import com.baghdad.remoteDataSource.RemoteSearchDataSourceImpl
 import com.baghdad.remoteDataSource.RemoteTvShowDataSourceImpl
-import com.baghdad.remoteDataSource.interceptor.ApiInterceptor
+import com.baghdad.remoteDataSource.interceptor.HeadersSetupInterceptor
+import com.baghdad.remoteDataSource.interceptor.KtorApiInterceptor
 import com.baghdad.repository.datasource.remote.RemoteActorDataSource
 import com.baghdad.repository.datasource.remote.RemoteEpisodeDataSource
 import com.baghdad.repository.datasource.remote.RemoteGenreDataSource
@@ -22,16 +23,22 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 
+private const val timeOut = 20L
 val remoteDataSourceModule = module {
     single<HttpClient> {
         HttpClient(CIO) {
             install(ContentNegotiation) {
                 json(Json { ignoreUnknownKeys = true })
             }
-            install(ApiInterceptor) {
+            install(KtorApiInterceptor) {
                 apiKey = BuildConfig.API_KEY
                 languageProvider = get()
             }
@@ -41,6 +48,35 @@ val remoteDataSourceModule = module {
                 socketTimeoutMillis = 20_000
             }
         }
+    }
+
+    single {
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+    }
+
+    single {
+        HeadersSetupInterceptor(get())
+    }
+
+    single {
+        OkHttpClient.Builder()
+            .callTimeout(timeOut, TimeUnit.SECONDS)
+            .connectTimeout(timeOut, TimeUnit.SECONDS)
+            .readTimeout(timeOut, TimeUnit.SECONDS)
+            .writeTimeout(timeOut, TimeUnit.SECONDS)
+            .addInterceptor(get<HttpLoggingInterceptor>())
+            .addInterceptor(get<HeadersSetupInterceptor>())
+            .build()
+    }
+
+    single {
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(get())
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
     }
 
     single(named("BASE_URL")) {
@@ -66,7 +102,6 @@ val remoteDataSourceModule = module {
             logger = get()
         )
     }
-
 
     single<RemoteMovieDataSource> {
         RemoteMovieDataSourceImpl(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ appcompat = "1.7.1"
 coilCompose = "3.2.0"
 composeBom = "2025.06.01"
 composeNavigation = "2.9.0"
+converterGson = "3.0.0"
 coreKtx = "1.16.0"
 espressoCore = "3.6.1"
 firebaseBom = "33.16.0"
@@ -21,9 +22,12 @@ kotlinxDatetime = "0.7.0"
 ksp = "2.0.21-1.0.27"
 ktor = "2.3.10"
 lifecycleRuntimeKtx = "2.9.1"
+loggingInterceptor = "4.10.0"
 material = "1.12.0"
 mockk = "1.14.2"
+okhttp = "4.10.0"
 readMoreVersion = "1.6.3"
+retrofit = "2.9.0"
 room = "2.7.2"
 runtimeAndroid = "1.8.3"
 uiGraphicsAndroid = "1.8.3"
@@ -48,6 +52,8 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 readmore-material3 = { group = "com.webtoonscorp.android", name = "readmore-material3", version.ref = "readMoreVersion" }
 
 # Material3
@@ -89,6 +95,11 @@ ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+
+#Retrofit
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
@@ -137,7 +148,7 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
-firebase-crashlytics = { id = "com.google.firebase.crashlytics",  version.ref = "crashlytics" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }
 firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "perf-plugin" }
 
 [bundles]
@@ -217,4 +228,11 @@ coil = [
     "coil",
     "coil-compose",
     "coil-network-okhttp"
+]
+
+retrofit = [
+    "retrofit",
+    "converter-gson",
+    "logging-interceptor",
+    "okhttp"
 ]

--- a/remote_datasource/build.gradle.kts
+++ b/remote_datasource/build.gradle.kts
@@ -50,4 +50,5 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.bundles.test.core)
     testImplementation(libs.ktor.client.mock)
+    implementation(libs.bundles.retrofit)
 }

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/KtorApiInterceptor.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/KtorApiInterceptor.kt
@@ -7,21 +7,21 @@ import io.ktor.client.request.HttpRequestPipeline
 import io.ktor.client.request.parameter
 import io.ktor.util.AttributeKey
 
-class ApiInterceptor(
+class KtorApiInterceptor(
     private val apiKey: String,
     private val languageProvider: LanguageProvider,
 ) {
 
-    companion object Plugin : HttpClientPlugin<Config, ApiInterceptor> {
+    companion object Plugin : HttpClientPlugin<Config, KtorApiInterceptor> {
 
-        override val key: AttributeKey<ApiInterceptor> = AttributeKey("ApiKeyInterceptor")
+        override val key: AttributeKey<KtorApiInterceptor> = AttributeKey("ApiKeyInterceptor")
 
-        override fun prepare(block: Config.() -> Unit): ApiInterceptor {
+        override fun prepare(block: Config.() -> Unit): KtorApiInterceptor {
             val config = Config().apply(block)
-            return ApiInterceptor(config.apiKey, config.languageProvider)
+            return KtorApiInterceptor(config.apiKey, config.languageProvider)
         }
 
-        override fun install(plugin: ApiInterceptor, scope: HttpClient) {
+        override fun install(plugin: KtorApiInterceptor, scope: HttpClient) {
             scope.requestPipeline.intercept(HttpRequestPipeline.Phases.State) {
                 context.parameter("api_key", plugin.apiKey)
                 context.parameter("language", plugin.languageProvider.getCurrentLanguage())

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/RetrofitInterceptor.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/RetrofitInterceptor.kt
@@ -1,0 +1,38 @@
+package com.baghdad.remoteDataSource.interceptor
+
+
+import com.baghdad.repository.language.LanguageProvider
+import okhttp3.Interceptor
+import okhttp3.Response
+import retrofit2.Invocation
+
+class HeadersSetupInterceptor(
+    private val languageProvider: LanguageProvider,
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val invocation = chain.request().tag(Invocation::class.java)
+            ?: return chain.proceed(chain.request())
+        val shouldAttachAuthHeader = invocation
+            .method()
+            .annotations
+            .any { it.annotationClass == Authenticated::class }
+
+        return chain.proceed(
+            chain.request()
+                .newBuilder().apply {
+                    if (shouldAttachAuthHeader) {
+                        // Uncomment the following lines if you have a user local data source to get the token
+//                        if (userLocalDataSource.getUserToken().isNotEmpty()) {
+//                            addHeader("Authorization", userLocalDataSource.getHeaderToken())
+//                        }
+                    }
+                    addHeader("Accept", "application/json")
+                    addHeader("language", languageProvider.getCurrentLanguage())
+                }
+                .build())
+    }
+}
+
+@Target(AnnotationTarget.FUNCTION)
+annotation class Authenticated

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/RetrofitInterceptor.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/interceptor/RetrofitInterceptor.kt
@@ -22,9 +22,12 @@ class HeadersSetupInterceptor(
             chain.request()
                 .newBuilder().apply {
                     if (shouldAttachAuthHeader) {
-                        // Uncomment the following lines if you have a user local data source to get the token
+                        // should replace this static token with saveToken logic
 //                        if (userLocalDataSource.getUserToken().isNotEmpty()) {
-//                            addHeader("Authorization", userLocalDataSource.getHeaderToken())
+                        addHeader(
+                            "Authorization",
+                            "Bearer eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyZTZkYmRkOTNjMGY5NzdkMjMwOGJjMzM3NmI3YTNmOCIsIm5iZiI6MTc1MzAyOTE3Ni45OSwic3ViIjoiNjg3ZDFhMzgzOTg0OWZmZThkZDk4ZDEzIiwic2NvcGVzIjpbImFwaV9yZWFkIl0sInZlcnNpb24iOjF9.5NDfRH9_oRVtrvQb8Bs11qWGeLzEE5US_e5IcVQWerE"
+                        )
 //                        }
                     }
                     addHeader("Accept", "application/json")

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/KtorApiInterceptorTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/KtorApiInterceptorTest.kt
@@ -1,6 +1,6 @@
 package com.baghdad.remoteDataSource
 
-import com.baghdad.remoteDataSource.interceptor.ApiInterceptor
+import com.baghdad.remoteDataSource.interceptor.KtorApiInterceptor
 import com.baghdad.repository.language.LanguageProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -14,8 +14,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 
-
-class ApiInterceptorTest {
+class KtorApiInterceptorTest {
     @Test
     fun `ApiInterceptor should adds api_key parameter to requests`() = runTest {
         val fakeApiKey = "TEST_KEY"
@@ -31,7 +30,7 @@ class ApiInterceptorTest {
             install(ContentNegotiation) {
                 json(Json)
             }
-            install(ApiInterceptor) {
+            install(KtorApiInterceptor) {
                 apiKey = fakeApiKey
                 languageProvider = mockLanguageProvider
             }
@@ -46,6 +45,6 @@ class ApiInterceptorTest {
         client.get("https://fake.api.com/test")
 
         assertTrue(capturedUrl!!.contains("api_key=$fakeApiKey"))
-        assertTrue(capturedUrl.contains("language=$fakeLanguage"))
+        assertTrue(capturedUrl!!.contains("language=$fakeLanguage"))
     }
 }


### PR DESCRIPTION
Initialized Retrofit as the main networking library.

Integrated OkHttp as the Retrofit client.

Implemented a custom interceptor for request/response handling (e.g., headers, logging, authentication).

Added necessary ProGuard rules to support Retrofit and prevent obfuscation-related runtime issues.