### PR TITLE
Fix/#298-cd app release time zone 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
-import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Properties
 
@@ -12,7 +13,8 @@ plugins {
     jacoco
 }
 
-val formattedDate: String = LocalDateTime.now().format(DateTimeFormatter.ofPattern("dd HH:mm"))
+val formattedDate: String = ZonedDateTime.now(ZoneId.of("Africa/Cairo"))
+    .format(DateTimeFormatter.ofPattern("dd HH:mm"))
 
 android {
     namespace = "com.baghdad.novix"
@@ -20,7 +22,7 @@ android {
 
     defaultConfig {
         applicationId = "com.baghdad.novix"
-        minSdk = 24
+        minSdk = 28
         targetSdk = 35
         versionName = "1.0-($formattedDate)"
         versionCode = 1


### PR DESCRIPTION
Updated the version name formatting logic to use ZonedDateTime with a fixed Egypt timezone (Africa/Cairo) to ensure consistent time-based versioning across environments.

Increased minSdk from 24 to 28 to align with project requirements and ensure compatibility with newer APIs.