### PR TITLE
Refactor/#354 issue scroll position state is not saved

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/component/lazyPaging/LazyPagingColumn.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/lazyPaging/LazyPagingColumn.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -16,6 +18,7 @@ import androidx.paging.compose.itemKey
 fun <T : Any> LazyPagingColumn(
     items: LazyPagingItems<T>,
     modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     verticalArrangement: Arrangement.Vertical = Arrangement.Top,
     key: ((item: T) -> Any)? = null,
@@ -24,6 +27,7 @@ fun <T : Any> LazyPagingColumn(
     itemContent: @Composable (item: T) -> Unit,
 ) {
     LazyColumn(
+        state = state,
         modifier = modifier.fillMaxSize(),
         contentPadding = contentPadding,
         verticalArrangement = verticalArrangement

--- a/ui/src/main/java/com/baghdad/ui/feature/component/lazyPaging/LazyPagingVerticalGrid.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/lazyPaging/LazyPagingVerticalGrid.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,9 +27,11 @@ fun <T : Any> LazyPagingVerticalGrid(
     key: ((item: T) -> Any)? = null,
     errorContent: @Composable () -> Unit = { DefaultErrorItem { items.retry() } },
     loadingContent: @Composable () -> Unit = { DefaultLoadingItem() },
+    state: LazyGridState = rememberLazyGridState(),
     itemContent: @Composable (item: T) -> Unit,
 ) {
     LazyVerticalGrid(
+        state = state,
         columns = columns,
         contentPadding = contentPadding,
         modifier = modifier.fillMaxSize(),

--- a/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
@@ -1,7 +1,6 @@
 package com.baghdad.ui.feature.search
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,12 +13,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.LazyGridState
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.saveable.listSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -42,6 +37,8 @@ import com.baghdad.ui.feature.search.component.SearchResultContent
 import com.baghdad.ui.feature.search.component.SearchTextField
 import com.baghdad.ui.feature.search.component.filter.FilterBottomSheet
 import com.baghdad.ui.feature.search.component.recentSearchSection
+import com.baghdad.ui.feature.util.remeberSaveableLazyListState
+import com.baghdad.ui.feature.util.rememberSaveableLazyGridState
 import com.baghdad.ui.navigation.graph.search.SearchNavEvent
 import com.baghdad.viewmodel.base.SnackBarState
 import com.baghdad.viewmodel.errorStates.BaseSnackBarMessage
@@ -108,7 +105,10 @@ fun SearchContent(
     actorItems: LazyPagingItems<SearchScreenState.ActorUiState>,
     tvShowItems: LazyPagingItems<SearchScreenState.TvShowUiState>
 ) {
-    val moviesState = rememberLazyGridState()
+    val moviesState = rememberSaveableLazyGridState(key = "movies_grid")
+    val actorsState = remeberSaveableLazyListState(key = "actors_list")
+    val tvShowsState = rememberSaveableLazyGridState(key = "tv_shows_grid")
+
     Scaffold(
         modifier = Modifier
             .background(Theme.color.surface)
@@ -156,6 +156,8 @@ fun SearchContent(
                         onActorClick = { listener.onActorItemClick(it) },
                         isLoading = uiState.isLoading,
                         moviesState = moviesState,
+                        actorsState = actorsState,
+                        tvShowsState = tvShowsState,
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
                 } else RecentlyViewsWithSearch(uiState, listener)
@@ -279,31 +281,5 @@ private fun SearchScreenPreview() {
             tvShowItems = flowOf(PagingData.empty<SearchScreenState.TvShowUiState>()).collectAsLazyPagingItems()
 
         )
-    }
-}
-
-
-//fun LazyGridStateSaver(): Saver<LazyGridState, Pair<Int, Int>> = Saver(
-//    save = { state -> state.firstVisibleItemIndex to state.firstVisibleItemScrollOffset },
-//    restore = { LazyGridState(firstVisibleItemIndex = it.first, firstVisibleItemScrollOffset = it.second) }
-//)
-
-//@Composable
-//fun rememberSaveableLazyGridState(): LazyGridState {
-//    return rememberSaveable(saver = LazyGridStateSaver()) {
-//        LazyGridState()
-//    }
-//}
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun rememberPersistentLazyGridState(key: String? = null): LazyGridState {
-    val saver = listSaver(
-        save = { listOf(it.firstVisibleItemIndex, it.firstVisibleItemScrollOffset) },
-        restore = { LazyGridState(it[0], it[1]) }
-    )
-    return if (key == null) {
-        rememberSaveable(saver = saver) { LazyGridState() }
-    } else {
-        rememberSaveable(key, saver = saver) { LazyGridState() }
     }
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
@@ -1,6 +1,7 @@
 package com.baghdad.ui.feature.search
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,8 +14,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -103,6 +108,7 @@ fun SearchContent(
     actorItems: LazyPagingItems<SearchScreenState.ActorUiState>,
     tvShowItems: LazyPagingItems<SearchScreenState.TvShowUiState>
 ) {
+    val moviesState = rememberLazyGridState()
     Scaffold(
         modifier = Modifier
             .background(Theme.color.surface)
@@ -149,6 +155,7 @@ fun SearchContent(
                         },
                         onActorClick = { listener.onActorItemClick(it) },
                         isLoading = uiState.isLoading,
+                        moviesState = moviesState,
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
                 } else RecentlyViewsWithSearch(uiState, listener)
@@ -272,5 +279,31 @@ private fun SearchScreenPreview() {
             tvShowItems = flowOf(PagingData.empty<SearchScreenState.TvShowUiState>()).collectAsLazyPagingItems()
 
         )
+    }
+}
+
+
+//fun LazyGridStateSaver(): Saver<LazyGridState, Pair<Int, Int>> = Saver(
+//    save = { state -> state.firstVisibleItemIndex to state.firstVisibleItemScrollOffset },
+//    restore = { LazyGridState(firstVisibleItemIndex = it.first, firstVisibleItemScrollOffset = it.second) }
+//)
+
+//@Composable
+//fun rememberSaveableLazyGridState(): LazyGridState {
+//    return rememberSaveable(saver = LazyGridStateSaver()) {
+//        LazyGridState()
+//    }
+//}
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun rememberPersistentLazyGridState(key: String? = null): LazyGridState {
+    val saver = listSaver(
+        save = { listOf(it.firstVisibleItemIndex, it.firstVisibleItemScrollOffset) },
+        restore = { LazyGridState(it[0], it[1]) }
+    )
+    return if (key == null) {
+        rememberSaveable(saver = saver) { LazyGridState() }
+    } else {
+        rememberSaveable(key, saver = saver) { LazyGridState() }
     }
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/ActorCardList.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/ActorCardList.kt
@@ -3,18 +3,19 @@ package com.baghdad.ui.feature.search.component
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.baghdad.design_system.component.ActorCard
 import com.baghdad.ui.feature.component.lazyPaging.LazyPagingColumn
-import com.baghdad.ui.feature.component.lazyPaging.LazyPagingColumn
 import com.baghdad.viewmodel.search.SearchScreenState
 
 
 @Composable
 fun ActorCardList(
+    state: LazyListState,
     actors: LazyPagingItems<SearchScreenState.ActorUiState>,
     onActorClick: (Long) -> Unit,
     modifier: Modifier = Modifier
@@ -24,6 +25,7 @@ fun ActorCardList(
         items = actors,
         verticalArrangement = Arrangement.spacedBy(8.dp),
         key = { it.id },
+        state = state,
         contentPadding = PaddingValues(vertical = 8.dp)
     ) { actor ->
         ActorCard(

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/MovieCardList.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/MovieCardList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -14,11 +15,13 @@ import com.baghdad.viewmodel.search.SearchScreenState
 
 @Composable
 fun MovieCardList(
+    state: LazyGridState,
     movies: LazyPagingItems<SearchScreenState.MovieUiState>,
     onSavedClick: (Long) -> Unit,
     onMovieClick: (id: Long, imageUrl: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+
     LazyPagingVerticalGrid<SearchScreenState.MovieUiState>(
         items = movies,
         modifier = modifier,
@@ -26,6 +29,7 @@ fun MovieCardList(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         key = { it.id },
+        state = state,
         contentPadding = PaddingValues(vertical = 8.dp)
     ) { movie ->
         HomeCard(

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/SearchResultContent.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/SearchResultContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,6 +30,8 @@ fun SearchResultContent(
     onTabSelected: (SearchScreenState.SearchTab) -> Unit,
     onSavedClick: (Long) -> Unit,
     moviesState: LazyGridState,
+    tvShowsState: LazyGridState,
+    actorsState: LazyListState,
     movies: LazyPagingItems<SearchScreenState.MovieUiState>,
     tvShows: LazyPagingItems<SearchScreenState.TvShowUiState>,
     actors: LazyPagingItems<SearchScreenState.ActorUiState>,
@@ -103,6 +106,7 @@ fun SearchResultContent(
             SearchScreenState.SearchTab.TV_SHOWS -> {
                 if (tvShows.itemCount != 0) {
                     TvShowCardList(
+                        state = tvShowsState,
                         tvShows = tvShows,
                         onSavedClick = onSavedClick,
                         onTVShowClick = onTvShowClick,
@@ -124,6 +128,7 @@ fun SearchResultContent(
             SearchScreenState.SearchTab.ACTORS -> {
                 if (actors.itemCount != 0) {
                     ActorCardList(
+                        state = actorsState,
                         actors = actors,
                         onActorClick = onActorClick,
                     )

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/SearchResultContent.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/SearchResultContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ fun SearchResultContent(
     selectedTab: SearchScreenState.SearchTab,
     onTabSelected: (SearchScreenState.SearchTab) -> Unit,
     onSavedClick: (Long) -> Unit,
+    moviesState: LazyGridState,
     movies: LazyPagingItems<SearchScreenState.MovieUiState>,
     tvShows: LazyPagingItems<SearchScreenState.TvShowUiState>,
     actors: LazyPagingItems<SearchScreenState.ActorUiState>,
@@ -78,6 +80,7 @@ fun SearchResultContent(
             SearchScreenState.SearchTab.MOVIES -> {
                 if (movies.itemCount != 0) {
                     MovieCardList(
+                        state = moviesState,
                         movies = movies,
                         onSavedClick = onSavedClick,
                         onMovieClick = onMovieClick,

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/TvShowCardList.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/TvShowCardList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -15,12 +16,14 @@ import com.baghdad.viewmodel.search.SearchScreenState
 @Composable
 fun TvShowCardList(
     tvShows: LazyPagingItems<SearchScreenState.TvShowUiState>,
+    state: LazyGridState,
     onSavedClick: (Long) -> Unit,
     onTVShowClick: (id: Long, imageUrl: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyPagingVerticalGrid<SearchScreenState.TvShowUiState>(
         items = tvShows,
+        state = state,
         modifier = modifier,
         columns = GridCells.Adaptive(minSize = 150.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),

--- a/ui/src/main/java/com/baghdad/ui/feature/util/RememberSaveableGridState.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/util/RememberSaveableGridState.kt
@@ -1,0 +1,22 @@
+package com.baghdad.ui.feature.util
+
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+fun rememberSaveableLazyGridState(
+    key: String? = null,
+    initialFirstVisibleItemIndex: Int = 0,
+    initialFirstVisibleItemScrollOffset: Int = 0
+): LazyGridState {
+    return rememberSaveable(
+        key = key,
+        saver = LazyGridState.Saver
+    ) {
+        LazyGridState(
+            firstVisibleItemIndex = initialFirstVisibleItemIndex,
+            firstVisibleItemScrollOffset = initialFirstVisibleItemScrollOffset
+        )
+    }
+}

--- a/ui/src/main/java/com/baghdad/ui/feature/util/RememberSaveableListState.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/util/RememberSaveableListState.kt
@@ -1,0 +1,19 @@
+package com.baghdad.ui.feature.util
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@Composable
+fun remeberSaveableLazyListState(
+    key: String? = null,
+    initialFirstVisibleItemIndex: Int = 0,
+    initialFirstVisibleItemScrollOffset: Int = 0
+): LazyListState {
+    return rememberSaveable(key = key, saver = LazyListState.Saver) {
+        LazyListState(
+            initialFirstVisibleItemIndex,
+            initialFirstVisibleItemScrollOffset
+        )
+    }
+}


### PR DESCRIPTION
## Enhancing user experience by saving the scroll position of each lazy grid/ list for movies, tv show and actors 
## related issue : #354 

### what has been done:
- creating custom rememberSaveable for lazy list and lazy grid 
- hoist the state of each lazy list or lazy grid 
- pass all these state down to their corresponding component

### by making these custom remeberSaveable for lazy list and grid we can save the scroll position in multiple situation 
- when user navigate between tabs of search (movies to tv show, tv show to actor and others ...)
- when user navigate between multiple screen (between home and search, profile to search and others ..)
- also when the user leave the app and return to it again (the state will survive this process) because we save this scrolling state within our app bundle (Android's state saving mechanism) using custom saver to enable saving complex state object like lazy gid and lazy list 


https://github.com/user-attachments/assets/84c947a6-1a8f-4078-875e-fb3e04d60a1b

