### PR TITLE
Feature/#219 unit test for remote datasource

### DIFF
--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteActorDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteActorDataSourceImplTest.kt
@@ -1,0 +1,155 @@
+package com.baghdad.remoteDataSource
+
+import com.baghdad.remoteDataSource.apiService.ActorApiService
+import com.baghdad.remoteDataSource.response.actor.ActorDetailsResponse
+import com.baghdad.remoteDataSource.response.actor.ActorImagesResponse
+import com.baghdad.remoteDataSource.response.actor.ActorMoviesResponse
+import com.baghdad.remoteDataSource.response.actor.ImageResponse
+import com.baghdad.remoteDataSource.response.actor.TrendingActorResponse
+import com.baghdad.repository.exception.NoInternetNetworkException
+import com.baghdad.repository.logger.Logger
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import retrofit2.Response
+
+class RemoteActorDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteActorDataSourceImpl
+    private lateinit var apiService: ActorApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        apiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteActorDataSourceImpl(apiService, logger)
+    }
+
+    @Test
+    fun `getActorImages should return formatted image URLs`() = runTest {
+        // Given
+        val personId = 456L
+        val apiResponse = ActorImagesResponse(
+            profiles = listOf(
+                ImageResponse(filePath = "/image1.jpg"),
+                ImageResponse(filePath = "/image2.jpg")
+            )
+        )
+        coEvery { apiService.getActorImages(personId) } returns Response.success(apiResponse)
+
+        // When
+        val result = dataSource.getActorImages(personId)
+
+        // Then
+        assertEquals(2, result.size)
+        assertEquals("https://image.tmdb.org/t/p/w500/image1.jpg", result[0])
+        assertEquals("https://image.tmdb.org/t/p/w500/image2.jpg", result[1])
+    }
+
+    @Test
+    fun `getActorMovies should return empty list when API returns null cast`() = runTest {
+        // Given
+        val personId = 789L
+        coEvery { apiService.getActorMovies(personId) } returns Response.success(
+            ActorMoviesResponse(
+                cast = null
+            )
+        )
+
+        // When
+        val result = dataSource.getActorMovies(personId)
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getActorImages should return empty list when profiles is empty`() = runTest {
+        // Given
+        val personId = 456L
+        val apiResponse = ActorImagesResponse(profiles = emptyList())
+        coEvery { apiService.getActorImages(personId) } returns Response.success(apiResponse)
+
+        // When
+        val result = dataSource.getActorImages(personId)
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getActorMovies should handle empty cast list`() = runTest {
+        // Given
+        val personId = 789L
+        coEvery { apiService.getActorMovies(personId) } returns Response.success(
+            ActorMoviesResponse(cast = emptyList())
+        )
+
+        // When
+        val result = dataSource.getActorMovies(personId)
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getTrendingActors should handle empty results list`() = runTest {
+        // Given
+        val page = 1
+        val apiResponse = TrendingActorResponse(
+            page = page,
+            results = emptyList(),
+            totalPages = 0,
+            totalResults = 0
+        )
+        coEvery { apiService.getTrendingActors(page) } returns Response.success(apiResponse)
+
+        // When
+        val result = dataSource.getTrendingActors(page)
+
+        // Then
+        assertTrue(result.data.isEmpty())
+    }
+
+    @Test
+    fun `getActorImages should throw exception on API failure`() = runTest {
+        // Given
+        val personId = 456L
+        coEvery { apiService.getActorImages(personId) } throws _root_ide_package_.io.ktor.utils.io.errors.IOException()
+
+        // When/Then
+        assertThrows<NoInternetNetworkException> {
+            dataSource.getActorImages(personId)
+        }
+    }
+
+    @Test
+    fun `getActorDetails should handle partial data`() = runTest {
+        // Given
+        val personId = 123L
+        val response = ActorDetailsResponse(
+            id = personId.toInt(),
+            name = null,
+            biography = null,
+            profilePath = null
+        )
+        coEvery { apiService.getActorDetails(personId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getActorDetails(personId)
+
+        // Then
+        assertEquals(personId, result.id)
+        assertEquals("", result.name)
+        assertEquals("", result.biography)
+        assertThat(result.headerPictures.isEmpty())
+    }
+
+}

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteEpisodeDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteEpisodeDataSourceImplTest.kt
@@ -1,0 +1,140 @@
+package com.baghdad.remoteDataSource
+
+
+import com.baghdad.remoteDataSource.apiService.EpisodeApiService
+import com.baghdad.remoteDataSource.response.CastMembersResponse
+import com.baghdad.remoteDataSource.response.episode.EpisodeDetailsResponse
+import com.baghdad.remoteDataSource.response.episode.EpisodeImageResponse
+import com.baghdad.repository.logger.Logger
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+
+
+class RemoteEpisodeDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteEpisodeDataSourceImpl
+    private lateinit var apiService: EpisodeApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        apiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteEpisodeDataSourceImpl(apiService, logger)
+    }
+
+    @Test
+    fun `getEpisodeDetails should return episode details when API call succeeds`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val episodeNumber = 1
+        val response = EpisodeDetailsResponse(
+            id = 123,
+            name = "Test Episode",
+            overview = "Test overview",
+
+            )
+        coEvery {
+            apiService.getEpisodeDetails(tvId, seasonNumber, episodeNumber)
+        } returns Response.success(response)
+
+        // When
+        val result = dataSource.getEpisodeDetails(tvId, seasonNumber, episodeNumber)
+
+        // Then
+        assertThat(result.id).isEqualTo(123L)
+        assertThat(result.title).isEqualTo("Test Episode")
+        assertThat(result.overview).isEqualTo("Test overview")
+    }
+
+    @Test
+    fun `getEpisodeCastMembers should return empty list when API returns null cast`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val episodeNumber = 1
+        coEvery {
+            apiService.getEpisodeCastMembers(tvId, seasonNumber, episodeNumber)
+        } returns Response.success(CastMembersResponse(cast = null))
+
+        // When
+        val result = dataSource.getEpisodeCastMembers(tvId, seasonNumber, episodeNumber)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getEpisodeImages should return formatted image URLs`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val episodeNumber = 1
+        val response = EpisodeImageResponse(
+            stills = listOf(
+                EpisodeImageResponse.Still(filePath = "/image1.jpg"),
+                EpisodeImageResponse.Still(filePath = "/image2.jpg")
+            )
+        )
+        coEvery {
+            apiService.getEpisodeImages(tvId, seasonNumber, episodeNumber)
+        } returns Response.success(response)
+
+        // When
+        val result = dataSource.getEpisodeImages(tvId, seasonNumber, episodeNumber)
+
+        // Then
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo("https://image.tmdb.org/t/p/w500/image1.jpg")
+        assertThat(result[1]).isEqualTo("https://image.tmdb.org/t/p/w500/image2.jpg")
+    }
+
+    @Test
+    fun `getEpisodeImages should return empty list when no stills available`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val episodeNumber = 1
+        val response = EpisodeImageResponse(stills = emptyList())
+        coEvery {
+            apiService.getEpisodeImages(tvId, seasonNumber, episodeNumber)
+        } returns Response.success(response)
+
+        // When
+        val result = dataSource.getEpisodeImages(tvId, seasonNumber, episodeNumber)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+
+    @Test
+    fun `getEpisodeDetails should handle minimal data response`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val episodeNumber = 1
+        val response = EpisodeDetailsResponse(
+            id = 123,
+            name = null,
+            overview = null,
+        )
+        coEvery {
+            apiService.getEpisodeDetails(tvId, seasonNumber, episodeNumber)
+        } returns Response.success(response)
+
+        // When
+        val result = dataSource.getEpisodeDetails(tvId, seasonNumber, episodeNumber)
+
+        // Then
+        assertThat(result.id).isEqualTo(123L)
+        assertThat(result.title).isEmpty()
+        assertThat(result.overview).isEmpty()
+    }
+}

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteGenreDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteGenreDataSourceImplTest.kt
@@ -1,0 +1,124 @@
+package com.baghdad.remoteDataSource
+
+import com.baghdad.remoteDataSource.apiService.GenreApiService
+import com.baghdad.remoteDataSource.response.GenreItemDto
+import com.baghdad.remoteDataSource.response.GenreListResponse
+import com.baghdad.repository.logger.Logger
+import com.baghdad.repository.model.GenreDto
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+
+class RemoteGenreDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteGenreDataSourceImpl
+    private lateinit var genreApiService: GenreApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        genreApiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteGenreDataSourceImpl(genreApiService, logger)
+    }
+
+    @Test
+    fun `getMovieGenre should return movie genres when API call succeeds`() = runTest {
+        // Given
+        val response = GenreListResponse(
+            genres = listOf(
+                GenreItemDto(id = 1, name = "Action"),
+                GenreItemDto(id = 2, name = "Comedy")
+            )
+        )
+        coEvery { genreApiService.getMovieGenre() } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieGenre("en")
+
+        // Then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(1)
+        assertThat(result[0].name).isEqualTo("Action")
+        assertThat(result[0].type).isEqualTo(GenreDto.GenreType.MOVIE)
+        assertThat(result[1].id).isEqualTo(2)
+        assertThat(result[1].name).isEqualTo("Comedy")
+        assertThat(result[1].type).isEqualTo(GenreDto.GenreType.MOVIE)
+    }
+
+    @Test
+    fun `getTvShowGenre should return TV show genres when API call succeeds`() = runTest {
+        // Given
+        val response = GenreListResponse(
+            genres = listOf(
+                GenreItemDto(id = 3, name = "Drama"),
+                GenreItemDto(id = 4, name = "Sci-Fi")
+            )
+        )
+        coEvery { genreApiService.getTvShowGenre() } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowGenre("en")
+
+        // Then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(3)
+        assertThat(result[0].name).isEqualTo("Drama")
+        assertThat(result[0].type).isEqualTo(GenreDto.GenreType.TV_SHOW)
+        assertThat(result[1].id).isEqualTo(4)
+        assertThat(result[1].name).isEqualTo("Sci-Fi")
+        assertThat(result[1].type).isEqualTo(GenreDto.GenreType.TV_SHOW)
+    }
+
+    @Test
+    fun `getMovieGenre should return empty list when API returns empty genres`() = runTest {
+        // Given
+        val response = GenreListResponse(genres = emptyList())
+        coEvery { genreApiService.getMovieGenre() } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieGenre("en")
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getTvShowGenre should return empty list when API returns null genres`() = runTest {
+        // Given
+        val response = GenreListResponse(genres = emptyList())
+        coEvery { genreApiService.getTvShowGenre() } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowGenre("en")
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getMovieGenre should include genres with empty names`() = runTest {
+        // Given
+        val response = GenreListResponse(
+            genres = listOf(
+                GenreItemDto(id = 1, name = ""),
+                GenreItemDto(id = 2, name = "Valid Genre")
+            )
+        )
+        coEvery { genreApiService.getMovieGenre() } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieGenre("en")
+
+        // Then
+        assertThat(result).hasSize(2)
+        assertThat(result[0].id).isEqualTo(1)
+        assertThat(result[0].name).isEmpty()
+        assertThat(result[1].id).isEqualTo(2)
+        assertThat(result[1].name).isEqualTo("Valid Genre")
+    }
+}

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteMovieDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteMovieDataSourceImplTest.kt
@@ -1,0 +1,171 @@
+package com.baghdad.remoteDataSource
+
+import com.baghdad.remoteDataSource.apiService.MovieApiService
+import com.baghdad.remoteDataSource.response.CastMemberResponse
+import com.baghdad.remoteDataSource.response.CastMembersResponse
+import com.baghdad.remoteDataSource.response.MovieResult
+import com.baghdad.remoteDataSource.response.SimilarMovieResponse
+import com.baghdad.remoteDataSource.response.actor.ImageResponse
+import com.baghdad.remoteDataSource.response.movie.Genre
+import com.baghdad.remoteDataSource.response.movie.MovieDetailsResponse
+import com.baghdad.remoteDataSource.response.movie.MovieImageResponse
+import com.baghdad.repository.logger.Logger
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+
+
+class RemoteMovieDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteMovieDataSourceImpl
+    private lateinit var movieApiService: MovieApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        movieApiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteMovieDataSourceImpl(movieApiService, logger)
+    }
+
+    @Test
+    fun `getMovieDetails should map response to MovieDto`() = runTest {
+        // Given
+        val movieId = 1L
+        val response = MovieDetailsResponse(
+            id = movieId,
+            title = "Test Movie",
+            genres = listOf(Genre(id = 1, name = "Action")),
+            voteAverage = 8.5,
+            releaseDate = "2023-01-01",
+            overview = "Test overview",
+            posterPath = "/poster.jpg",
+            runtime = 120
+        )
+        coEvery { movieApiService.getMovieDetails(movieId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieDetails(movieId)
+
+        // Then
+        assertThat(result.id).isEqualTo(movieId)
+        assertThat(result.title).isEqualTo("Test Movie")
+        assertThat(result.genres).hasSize(1)
+        assertThat(result.imdbRating).isEqualTo(8.5)
+        assertThat(result.releaseDate).isEqualTo("2023-01-01")
+        assertThat(result.runtimeMinutes).isEqualTo(120)
+    }
+
+    @Test
+    fun `getSimilarMovies should map response to MovieDto list`() = runTest {
+        // Given
+        val movieId = 1L
+        val response = SimilarMovieResponse(
+            results = listOf(
+                MovieResult(
+                    id = 1,
+                    title = "Similar 1",
+                    posterPath = "/similar1.jpg"
+                )
+            )
+        )
+        coEvery { movieApiService.getSimilarMovies(movieId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getSimilarMovies(movieId)
+
+        // Then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].id).isEqualTo(1L)
+        assertThat(result[0].title).isEqualTo("Similar 1")
+    }
+
+    @Test
+    fun `getMovieImages should return backdrop paths`() = runTest {
+        // Given
+        val movieId = 1L
+        val response = MovieImageResponse(
+            backdrops = listOf(
+                ImageResponse(filePath = "/backdrop1.jpg")
+            )
+        )
+        coEvery { movieApiService.getMovieImages(movieId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieImages(movieId)
+
+        // Then
+        assertThat(result).containsExactly("/backdrop1.jpg")
+    }
+
+    @Test
+    fun `getTopRatedMovies should return paged results`() = runTest {
+        // Given
+        val page = 1
+        val response = SimilarMovieResponse(
+            page = page,
+            results = listOf(
+                MovieResult(id = 1, title = "Top Movie")
+            ),
+            totalPages = 10
+        )
+        coEvery { movieApiService.getTopRatedMovies(page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTopRatedMovies(page)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun `getMoviesByGenre should return paged results`() = runTest {
+        // Given
+        val genreId = 1L
+        val page = 1
+        val response = SimilarMovieResponse(
+            page = page,
+            results = listOf(
+                MovieResult(id = 1, title = "Action Movie")
+            ),
+            totalPages = 5
+        )
+        coEvery { movieApiService.getMoviesByGenre(genreId, page) } returns Response.success(
+            response
+        )
+
+        // When
+        val result = dataSource.getMoviesByGenre(genreId, page)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+    }
+
+    @Test
+    fun `getMovieCastMembers should return cast list`() = runTest {
+        // Given
+        val movieId = 1L
+        val response = CastMembersResponse(
+            cast = listOf(
+                CastMemberResponse(
+                    id = 1,
+                    name = "Actor",
+                    character = "Hero"
+                )
+            )
+        )
+        coEvery { movieApiService.getMovieCastMembers(movieId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMovieCastMembers(movieId)
+
+        // Then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].actor.name).isEqualTo("Actor")
+        assertThat(result[0].characterName).isEqualTo("Hero")
+    }
+}

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteSearchDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteSearchDataSourceImplTest.kt
@@ -1,0 +1,226 @@
+package com.baghdad.remoteDataSource
+
+import com.baghdad.remoteDataSource.apiService.SearchApiService
+import com.baghdad.remoteDataSource.response.search.ActorSearchResponse
+import com.baghdad.remoteDataSource.response.search.MovieSearchResponse
+import com.baghdad.remoteDataSource.response.search.TvShowSearchResponse
+import com.baghdad.repository.logger.Logger
+import com.baghdad.repository.model.GenreDto
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+
+import retrofit2.Response
+
+class RemoteSearchDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteSearchDataSourceImpl
+    private lateinit var searchApiService: SearchApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        searchApiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteSearchDataSourceImpl(searchApiService, logger)
+    }
+
+    @Test
+    fun `searchMovies should return paged movie results`() = runTest {
+        // Given
+        val query = "test"
+        val page = 1
+        val genres = listOf(GenreDto(1, "Action", GenreDto.GenreType.MOVIE))
+        val response = MovieSearchResponse(
+            page = page,
+            results = listOf(
+                MovieSearchResponse.Result(
+                    id = 1,
+                    title = "Test Movie",
+                    posterPath = "/poster.jpg"
+                )
+            ),
+            totalPages = 10
+        )
+        coEvery { searchApiService.searchMovies(query, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.searchMovies(query, page, genres)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+        assertThat(result.data[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getMoviesResultCount should return total results count`() = runTest {
+        // Given
+        val title = "test"
+        val response = MovieSearchResponse(totalResults = 100)
+        coEvery { searchApiService.getMoviesResultCount(title) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMoviesResultCount(title)
+
+        // Then
+        assertThat(result).isEqualTo(100)
+    }
+
+    @Test
+    fun `searchTvShows should return paged tv show results`() = runTest {
+        // Given
+        val query = "test"
+        val page = 1
+        val genres = listOf(GenreDto(1, "Drama", GenreDto.GenreType.TV_SHOW))
+        val response = TvShowSearchResponse(
+            page = page,
+            results = listOf(
+                TvShowSearchResponse.Result(
+                    id = 1,
+                    title = "Test Show",
+                    posterPath = "/poster.jpg"
+                )
+            ),
+            totalPages = 5
+        )
+        coEvery { searchApiService.searchTvShows(query, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.searchTvShows(query, page, genres)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+        assertThat(result.data[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getTvShowsResultCount should return total results count`() = runTest {
+        // Given
+        val title = "test"
+        val response = TvShowSearchResponse(totalResults = 50)
+        coEvery { searchApiService.getTvShowsResultCount(title) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowsResultCount(title)
+
+        // Then
+        assertThat(result).isEqualTo(50)
+    }
+
+    @Test
+    fun `searchActors should return paged actor results`() = runTest {
+        // Given
+        val query = "john"
+        val page = 1
+        val response = ActorSearchResponse(
+            page = page,
+            results = listOf(
+                ActorSearchResponse.Result(
+                    id = 1,
+                    name = "John Doe",
+                    profilePath = "/profile.jpg"
+                )
+            ),
+            totalPages = 3
+        )
+        coEvery { searchApiService.searchActors(query, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.searchActors(query, page)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+        assertThat(result.data[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getActorsResultCount should return total results count`() = runTest {
+        // Given
+        val name = "john"
+        val response = ActorSearchResponse(totalResults = 25)
+        coEvery { searchApiService.getActorsResultCount(name) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getActorsResultCount(name)
+
+        // Then
+        assertThat(result).isEqualTo(25)
+    }
+
+    @Test
+    fun `searchMovies should handle empty results`() = runTest {
+        // Given
+        val query = "none"
+        val page = 1
+        val genres = emptyList<GenreDto>()
+        val response = MovieSearchResponse(results = emptyList())
+        coEvery { searchApiService.searchMovies(query, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.searchMovies(query, page, genres)
+
+        // Then
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `searchTvShows should handle null results`() = runTest {
+        // Given
+        val query = "none"
+        val page = 1
+        val genres = emptyList<GenreDto>()
+        val response = TvShowSearchResponse(results = null)
+        coEvery { searchApiService.searchTvShows(query, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.searchTvShows(query, page, genres)
+
+        // Then
+        assertThat(result.data).isEmpty()
+    }
+
+    @Test
+    fun `getMoviesResultCount should return 0 when null`() = runTest {
+        // Given
+        val title = "unknown"
+        val response = MovieSearchResponse(totalResults = null)
+        coEvery { searchApiService.getMoviesResultCount(title) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getMoviesResultCount(title)
+
+        // Then
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `getTvShowsResultCount should return 0 when null`() = runTest {
+        // Given
+        val title = "unknown"
+        val response = TvShowSearchResponse(totalResults = null)
+        coEvery { searchApiService.getTvShowsResultCount(title) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowsResultCount(title)
+
+        // Then
+        assertThat(result).isEqualTo(0)
+    }
+
+    @Test
+    fun `getActorsResultCount should return 0 when null`() = runTest {
+        // Given
+        val name = "unknown"
+        val response = ActorSearchResponse(totalResults = null)
+        coEvery { searchApiService.getActorsResultCount(name) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getActorsResultCount(name)
+
+        // Then
+        assertThat(result).isEqualTo(0)
+    }
+}

--- a/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteTvShowDataSourceImplTest.kt
+++ b/remote_datasource/src/test/java/com/baghdad/remoteDataSource/RemoteTvShowDataSourceImplTest.kt
@@ -1,0 +1,195 @@
+package com.baghdad.remoteDataSource
+
+import com.baghdad.remoteDataSource.apiService.TvShowApiService
+import com.baghdad.remoteDataSource.response.CastMemberResponse
+import com.baghdad.remoteDataSource.response.CastMembersResponse
+import com.baghdad.remoteDataSource.response.actor.ImageResponse
+import com.baghdad.remoteDataSource.response.tvShow.EpisodeResponse
+import com.baghdad.remoteDataSource.response.tvShow.SeasonDetailResponse
+import com.baghdad.remoteDataSource.response.tvShow.TVShowDetailsResponse
+import com.baghdad.remoteDataSource.response.tvShow.TVShowImagesResponse
+import com.baghdad.remoteDataSource.response.tvShow.TrendingTvShowsResponse
+import com.baghdad.remoteDataSource.response.tvShow.TvShowResponse
+import com.baghdad.repository.logger.Logger
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import retrofit2.Response
+
+class RemoteTvShowDataSourceImplTest {
+
+    private lateinit var dataSource: RemoteTvShowDataSourceImpl
+    private lateinit var tvShowApiService: TvShowApiService
+    private lateinit var logger: Logger
+
+    @BeforeEach
+    fun setUp() {
+        tvShowApiService = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        dataSource = RemoteTvShowDataSourceImpl(tvShowApiService, logger)
+    }
+
+    @Test
+    fun `getTvShowCastMembers should return cast members`() = runTest {
+        // Given
+        val tvId = 1L
+        val response = CastMembersResponse(
+            cast = listOf(
+                CastMemberResponse(
+                    id = 1,
+                    name = "Actor 1",
+                    character = "Character 1",
+                    profilePath = "/actor1.jpg"
+                )
+            )
+        )
+        coEvery { tvShowApiService.getTvShowCastMembers(tvId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowCastMembers(tvId)
+
+        // Then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].actor.id).isEqualTo(1L)
+        assertThat(result[0].characterName).isEqualTo("Character 1")
+    }
+
+    @Test
+    fun `getTvShowImages should return formatted image URLs`() = runTest {
+        // Given
+        val tvId = 1L
+        val response = TVShowImagesResponse(
+            backdrops = listOf(
+                ImageResponse(filePath = "/backdrop1.jpg"),
+                ImageResponse(filePath = "/backdrop2.jpg")
+            )
+        )
+        coEvery { tvShowApiService.getTvShowImages(tvId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowImages(tvId)
+
+        // Then
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).isEqualTo("https://image.tmdb.org/t/p/w500/backdrop1.jpg")
+    }
+
+    @Test
+    fun `getTvShowsByGenre should return TV shows list`() = runTest {
+        // Given
+        val genreId = 1L
+        val page = 1
+        val response = TvShowResponse(
+            results = listOf(
+                TVShowDetailsResponse(
+                    id = 1,
+                    name = "Show 1"
+                )
+            )
+        )
+        coEvery { tvShowApiService.getTvShowsByGenre(genreId, page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowsByGenre(genreId, page)
+
+        // Then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getTvShowEpisodes should return episodes list`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val response = SeasonDetailResponse(
+            episodes = listOf(
+                EpisodeResponse(
+                    id = 1,
+                    name = "Episode 1",
+                    episodeNumber = 1
+                )
+            )
+        )
+        coEvery { tvShowApiService.getTvShowEpisodes(tvId, seasonNumber) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowEpisodes(tvId, seasonNumber)
+
+        // Then
+        assertThat(result).hasSize(1)
+        assertThat(result[0].id).isEqualTo(1L)
+        assertThat(result[0].episodeNumber).isEqualTo(1)
+    }
+
+    @Test
+    fun `getTrendingTvShows should return paged results`() = runTest {
+        // Given
+        val page = 1
+        val response = TrendingTvShowsResponse(
+            page = page,
+            results = listOf(
+                TrendingTvShowsResponse.TrendingTvShow(
+                    id = 1,
+                    name = "Trending Show"
+                )
+            ),
+            totalPages = 10
+        )
+        coEvery { tvShowApiService.getTrendingTvShows(page) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTrendingTvShows(page)
+
+        // Then
+        assertThat(result.data).hasSize(1)
+        assertThat(result.data[0].id).isEqualTo(1L)
+    }
+
+    @Test
+    fun `getTvShowCastMembers should return empty list when null cast`() = runTest {
+        // Given
+        val tvId = 1L
+        val response = CastMembersResponse(cast = null)
+        coEvery { tvShowApiService.getTvShowCastMembers(tvId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowCastMembers(tvId)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getTvShowImages should return empty list when null backdrops`() = runTest {
+        // Given
+        val tvId = 1L
+        val response = TVShowImagesResponse(backdrops = null)
+        coEvery { tvShowApiService.getTvShowImages(tvId) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowImages(tvId)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `getTvShowEpisodes should return empty list when null episodes`() = runTest {
+        // Given
+        val tvId = 1L
+        val seasonNumber = 1
+        val response = SeasonDetailResponse(episodes = null)
+        coEvery { tvShowApiService.getTvShowEpisodes(tvId, seasonNumber) } returns Response.success(response)
+
+        // When
+        val result = dataSource.getTvShowEpisodes(tvId, seasonNumber)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+}

--- a/repository/src/main/java/com/baghdad/repository/model/CastMemberDto.kt
+++ b/repository/src/main/java/com/baghdad/repository/model/CastMemberDto.kt
@@ -1,6 +1,5 @@
 package com.baghdad.repository.model
 
-import com.baghdad.repository.model.ActorDto
 
 data class CastMemberDto(
     val actor: ActorDto,


### PR DESCRIPTION
## Description
Added comprehensive unit tests for remote data source implementations This covers:
- `RemoteActorDataSourceImpl`
- `RemoteEpisodeDataSourceImpl`
- `RemoteGenreDataSourceImpl` 
- `RemoteMovieDataSourceImpl`
- `RemoteSearchDataSourceImpl`
- `RemoteTvShowDataSourceImpl`

## Related Issue 
[add unit test for remote datasource #219 ](https://github.com/Baghdad-Squad/Novix/issues/219)