### PR TITLE
Fix/ reset genre filter on tab switch in TopRatingScreen and ViewModel

### DIFF
--- a/design_system/src/main/java/com/baghdad/design_system/component/Tab.kt
+++ b/design_system/src/main/java/com/baghdad/design_system/component/Tab.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.baghdad.design_system.modifier.noRippleClickable
+import com.baghdad.design_system.theme.NovixTheme
 import com.baghdad.design_system.theme.Theme
 
 
@@ -65,8 +67,7 @@ fun Tab(
                 .padding(horizontal = 24.dp)
                 .animateContentSize(tween(ANIMATION_DURATION))
                 .noRippleClickable { onClick() }
-                .then(underlineModifier)
-            ,
+                .then(underlineModifier),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center) {
             Text(
@@ -124,3 +125,11 @@ private fun AnimatedUnderlineWrapper(
 }
 
 private const val ANIMATION_DURATION = 200
+
+@Preview
+@Composable
+private fun TabsPreview() {
+    NovixTheme {
+        Tab(text = "Tab 1", isSelected = true, onClick = {})
+    }
+}

--- a/ui/src/main/java/com/baghdad/ui/feature/topRating/TopRatingScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/topRating/TopRatingScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -91,12 +92,11 @@ private fun TopRatingContent(
     tvShowItems: LazyPagingItems<TopRatingState.TvShowUiState>
 ) {
     Scaffold(
-        modifier =
-            Modifier
-                .background(Theme.color.surface)
+        modifier = Modifier
+            .background(Theme.color.surface)
             .systemBarsPadding()
             .statusBarsPadding(),
-            topBar = {
+        topBar = {
             TopAppBar(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -129,16 +129,17 @@ private fun TopRatingContent(
                     modifier = Modifier.weight(1f)
                 )
             }
-            GenresSection(
-                allGenres = uiState.genres,
-                selectedGenres = uiState.selectedGenreId,
-                onGenreSelected = { listener.onGenreClick(it?.id) },
-                modifier = Modifier
-                    .background(Theme.color.surface)
-                    .padding(start = 16.dp, top = 12.dp, bottom = 12.dp)
-            )
 
-
+            key(uiState.selectedTab) {
+                GenresSection(
+                    allGenres = uiState.genres,
+                    selectedGenres = uiState.selectedGenreId,
+                    onGenreSelected = { listener.onGenreClick(it?.id) },
+                    modifier = Modifier
+                        .background(Theme.color.surface)
+                        .padding(start = 16.dp, top = 12.dp, bottom = 12.dp)
+                )
+            }
         },
         snackbar = {
             SnackBar(

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingInteractionListener.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingInteractionListener.kt
@@ -2,9 +2,7 @@ package com.baghdad.viewmodel.topRating
 
 interface TopRatingInteractionListener {
     fun onMovieDetailsClick(movieId: Long)
-
     fun onGenreClick(genreId: Long?)
-
     fun onSaveMovieClick(movieId: Long)
     fun onBackClick()
     fun onSelectedTab(selectedTab: TopRatingTab)

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
@@ -39,7 +39,7 @@ class TopRatingViewModel(
                 genres =
                     genres.distinctBy { genre -> genre.id }.map { genre ->
                         genre.toTopRatingGenreUiState()
-                    },
+                    }
             )
         }
 
@@ -75,7 +75,7 @@ class TopRatingViewModel(
             },
             onInitialLoadFinished = ::onFinally,
             mapEntityToUiState = { it.toTopRatingMovieUiState() },
-            onFlowCreated = { moviesFlow -> updateState { it.copy(moviesFlow = moviesFlow) } },
+            onFlowCreated = { moviesFlow -> updateState { it.copy(moviesFlow = moviesFlow) } }
         )
     }
 
@@ -104,19 +104,17 @@ class TopRatingViewModel(
 
     override fun onSelectedTab(selectedTab: TopRatingTab) {
         updateState {
-            it.copy(selectedTab = selectedTab)
+            it.copy(selectedTab = selectedTab, selectedGenreId = null)
         }
         when (selectedTab) {
             TopRatingTab.MOVIES -> {
-
                 getMovieGenres()
-
-                fetchMoviesByGenre(currentState.selectedGenreId)
+                fetchMoviesByGenre(null)
             }
 
             TopRatingTab.TV_SHOWS -> {
                 getTvShowGenres()
-                fetchTvShowsByGenre(currentState.selectedGenreId)
+                fetchTvShowsByGenre(null)
             }
         }
     }
@@ -125,5 +123,7 @@ class TopRatingViewModel(
         updateState { it.copy(isLoading = false) }
     }
 
-    override fun mapThrowableToErrorMessage(throwable: Throwable): BaseSnackBarMessage = BaseSnackBarMessage.UnknownError
+    override fun mapThrowableToErrorMessage(throwable: Throwable): BaseSnackBarMessage =
+        BaseSnackBarMessage.UnknownError
+
 }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
@@ -109,12 +109,12 @@ class TopRatingViewModel(
         when (selectedTab) {
             TopRatingTab.MOVIES -> {
                 getMovieGenres()
-                fetchMoviesByGenre(null)
+                fetchMoviesByGenre(currentState.selectedGenreId)
             }
 
             TopRatingTab.TV_SHOWS -> {
                 getTvShowGenres()
-                fetchTvShowsByGenre(null)
+                fetchTvShowsByGenre(currentState.selectedGenreId)
             }
         }
     }


### PR DESCRIPTION
In this PR we improve genre filtering scroll state across tab changing

[genress.webm](https://github.com/user-attachments/assets/6aa22802-efa9-4eae-a5ec-c8254105670f)
