### PR TITLE
Fix: actor card border direction

### DIFF
--- a/design_system/src/main/java/com/baghdad/design_system/modifier/ThreeSidedBorder.kt
+++ b/design_system/src/main/java/com/baghdad/design_system/modifier/ThreeSidedBorder.kt
@@ -1,5 +1,8 @@
 package com.baghdad.design_system.modifier
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Rect
@@ -7,17 +10,25 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 
 fun Modifier.threeSidedBorder(
     width: Dp,
     color: Color,
-    cornerRadius: Dp
+    cornerRadius: Dp,
+    isRTL: Boolean = false
 ) = this.drawBehind {
     val cornerRadiusInPx = cornerRadius.toPx()
     val path = Path().apply {
-        drawBorderPath(width.toPx(), size, cornerRadiusInPx)
+        if (isRTL) {
+            drawBorderPathRtl(width.toPx(), size, cornerRadiusInPx)
+        } else {
+            drawBorderPath(width.toPx(), size, cornerRadiusInPx)
+
+        }
     }
 
     drawPath(
@@ -35,9 +46,59 @@ private fun Path.drawBorderPath(strokeWidth: Float, size: Size, cornerRadius: Fl
 
     lineTo(size.width - (strokeWidth / 2), size.height - (strokeWidth / 2) - cornerRadius)
 
-    addBottomRightCorner(size.width - (strokeWidth / 2), size.height - (strokeWidth / 2), cornerRadius)
+    addBottomRightCorner(
+        size.width - (strokeWidth / 2),
+        size.height - (strokeWidth / 2),
+        cornerRadius
+    )
 
     lineTo(0f, size.height - (strokeWidth / 2))
+}
+
+private fun Path.drawBorderPathRtl(strokeWidth: Float, size: Size, cornerRadius: Float) {
+    val halfStroke = strokeWidth / 2f
+
+    moveTo(size.width, 0f)
+    lineTo(halfStroke + cornerRadius, 0f)
+    addTopLeftCorner(offsetX = halfStroke, radius = cornerRadius)
+
+    lineTo(halfStroke, size.height - halfStroke - cornerRadius)
+    addBottomLeftCorner(
+        offsetX = halfStroke,
+        height = size.height - halfStroke,
+        radius = cornerRadius
+    )
+    lineTo(size.width, size.height - halfStroke)
+}
+
+
+private fun Path.addTopLeftCorner(offsetX: Float, radius: Float) {
+    arcTo(
+        rect = Rect(
+            left = offsetX,
+            top = 0f,
+            right = offsetX + radius * 2,
+            bottom = radius * 2
+        ),
+        startAngleDegrees = 270f,
+        sweepAngleDegrees = -90f,
+        forceMoveTo = false
+    )
+}
+
+
+private fun Path.addBottomLeftCorner(offsetX: Float, height: Float, radius: Float) {
+    arcTo(
+        rect = Rect(
+            left = offsetX,
+            top = height - radius * 2,
+            right = offsetX + radius * 2,
+            bottom = height
+        ),
+        startAngleDegrees = 180f,
+        sweepAngleDegrees = -90f,
+        forceMoveTo = false
+    )
 }
 
 private fun Path.addTopRightCorner(width: Float, radius: Float) {
@@ -66,4 +127,14 @@ private fun Path.addBottomRightCorner(width: Float, height: Float, radius: Float
         sweepAngleDegrees = 90f,
         forceMoveTo = false
     )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, showSystemUi = true)
+@Composable
+fun PreviewThreeSidedBorder() {
+    Box(
+        modifier = Modifier
+            .size(100.dp)
+            .threeSidedBorder(2.dp, Color.Black, 10.dp, true)
+    ) {}
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/component/ActorCard.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/ActorCard.kt
@@ -17,14 +17,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.baghdad.design_system.R
 import com.baghdad.design_system.component.Text
 import com.baghdad.design_system.modifier.noRippleClickable
 import com.baghdad.design_system.modifier.threeSidedBorder
+import com.baghdad.design_system.preview.NovixPreviews
 import com.baghdad.design_system.theme.NovixTheme
 import com.baghdad.design_system.theme.Theme
 import com.baghdad.ui.feature.component.islamicImage.IslamicImage
@@ -34,9 +36,7 @@ private val ActorImageSize = 78.dp
 private val RoundedShapeValue = 12.dp
 
 private val ImageShape = RoundedCornerShape(
-    topEnd = RoundedShapeValue,
-    topStart = RoundedShapeValue,
-    bottomStart = RoundedShapeValue
+    topEnd = RoundedShapeValue, topStart = RoundedShapeValue, bottomStart = RoundedShapeValue
 )
 private val CardShape = RoundedCornerShape(
     topEnd = RoundedShapeValue,
@@ -51,12 +51,12 @@ fun ActorCard(
     modifier: Modifier = Modifier,
     characterName: String? = null
 ) {
+    val isRTL = LocalLayoutDirection.current == LayoutDirection.Rtl
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(color = Theme.color.surface)
-            .noRippleClickable { onClick() }
-    ) {
+            .noRippleClickable { onClick() }) {
         IslamicImage(
             imageUrl = actorImage,
             contentDescription = stringResource(R.string.actor_image),
@@ -74,7 +74,10 @@ fun ActorCard(
                 .widthIn(min = 218.dp)
                 .background(Theme.color.surface)
                 .threeSidedBorder(
-                    width = 1.dp, color = Theme.color.stroke, cornerRadius = RoundedShapeValue
+                    width = 1.dp,
+                    color = Theme.color.stroke,
+                    cornerRadius = RoundedShapeValue,
+                    isRTL = isRTL
                 )
                 .clip(CardShape)
                 .height(CardHeight)
@@ -100,10 +103,10 @@ fun ActorCard(
     }
 }
 
-@Preview
+@NovixPreviews
 @Composable
 private fun ActorCardPreview() {
-    NovixTheme(isDarkTheme = true) {
+    NovixTheme(isDarkTheme = false) {
         Box(
             modifier = Modifier.background(Theme.color.surface)
         ) {


### PR DESCRIPTION
## Fix actor card border layout direction in both right to left and left to right direction
 
<img width="1080" height="2280" alt="actor_rtl2" src="https://github.com/user-attachments/assets/382a7cd9-3356-48ac-8f84-7ebcf51bbbf8" />
<img width="162" height="276" alt="actor_rtl1" src="https://github.com/user-attachments/assets/e7a5f267-8f56-4862-ac7c-1db605b4a149" />
<img width="1080" height="2280" alt="actor_rtl3" src="https://github.com/user-attachments/assets/257aa235-c103-428f-8798-03b28a8170ec" />
