### PR TITLE
Fix/#418 fix tv show details screen

### DIFF
--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/episode/EpisodeDetailsResponseMapper.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/episode/EpisodeDetailsResponseMapper.kt
@@ -9,7 +9,7 @@ fun EpisodeDetailsResponse.toDto(): EpisodeDto {
         title = this.name.orEmpty(),
         episodeNumber = this.episodeNumber,
         rating = this.voteAverage,
-        duration = "${this.runtime} min",
+        duration = "${this.runtime}",
         releasedDate = this.airDate.orEmpty(),
         currentSeason = this.seasonNumber,
         overview = this.overview.orEmpty(),

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/episode/EpisodeResponseMapper.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/episode/EpisodeResponseMapper.kt
@@ -9,7 +9,7 @@ fun EpisodeResponse.toDto(): EpisodeDto {
         title = this.name.orEmpty(),
         episodeNumber = this.episodeNumber ?: 0,
         rating = this.voteAverage ?: 0.0,
-        duration = "${this.runtime ?: 0} min",
+        duration = "${this.runtime ?: 0}",
         releasedDate = this.airDate ?: "0001-01-01",
         currentSeason = this.seasonNumber ?: 0,
         overview = this.overview.orEmpty(),

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/FilterBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/FilterBottomSheet.kt
@@ -79,7 +79,6 @@ fun FilterBottomSheet(
                 onClearClick = onClearClick,
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
-                    .padding(bottom = 24.dp)
             )
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/topRating/TopRatingScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/topRating/TopRatingScreen.kt
@@ -38,6 +38,7 @@ import com.baghdad.ui.navigation.graph.home.HomeNavEvent.NavigateBack
 import com.baghdad.ui.navigation.graph.home.HomeNavEvent.NavigateToMovieDetails
 import com.baghdad.viewmodel.base.SnackBarState
 import com.baghdad.viewmodel.errorStates.BaseSnackBarMessage
+import com.baghdad.viewmodel.errorStates.SearchSnackBarMessage
 import com.baghdad.viewmodel.topRating.TopRatingEffect
 import com.baghdad.viewmodel.topRating.TopRatingInteractionListener
 import com.baghdad.viewmodel.topRating.TopRatingState
@@ -224,5 +225,8 @@ private fun TopRatingContent(
 
 @Composable
 private fun snackBarMessage(type: BaseSnackBarMessage): Int {
-    return type.toStringResource()
+    return when (type) {
+        SearchSnackBarMessage.SavedItemSuccessfully -> com.baghdad.ui.R.string.snackbar_saved_success
+        else -> type.toStringResource()
+    }
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
@@ -225,25 +225,26 @@ fun TvShowDetailsContent(
                     }
                 }
 
-                    item {
-                        SeasonSection(
-                            seasonCount = uiState.tvShowInfo.seasonCount,
-                            selectedSeasonIndex = uiState.selectedSeasonIndex,
-                            onSeasonSelected = { listener.onClickSeasonTab(it) },
-                            modifier = Modifier.padding(bottom = 8.dp)
-                        )
-                    }
+                item {
+                    SeasonSection(
+                        seasonCount = uiState.tvShowInfo.seasonCount,
+                        selectedSeasonIndex = uiState.selectedSeasonIndex,
+                        onSeasonSelected = { listener.onClickSeasonTab(it) },
+                        modifier = Modifier.padding(bottom = 8.dp)
+                    )
+                }
 
-                    item {
-                        Text(
-                            text = stringResource(R.string.episodes, uiState.episodes.size),
-                            style = Theme.typography.label.small,
-                            color = Theme.color.hint,
-                            modifier = Modifier
-                                .padding(horizontal = 16.dp)
-                                .padding(bottom = 12.dp)
-                        )
-                    }
+                item {
+                    Text(
+                        text = stringResource(R.string.episodes, uiState.episodes.size),
+                        style = Theme.typography.label.small,
+                        color = Theme.color.hint,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .padding(bottom = 12.dp)
+                    )
+                }
+
 
                 if (uiState.episodes.isNotEmpty()) {
                     items(uiState.episodes) { episode ->
@@ -267,6 +268,7 @@ fun TvShowDetailsContent(
                     }
                 }
             }
+
             TopAppBar(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -290,9 +292,7 @@ fun TvShowDetailsContent(
             )
         }
     }
-
 }
-
 
 @Composable
 private fun snackBarMessage(type: BaseSnackBarMessage): Int {

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/EpisodesCard.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/EpisodesCard.kt
@@ -88,7 +88,7 @@ fun EpisodeCard(
                                 .align(Alignment.CenterVertically)
                         )
                         LabeledIconRow(
-                            title = duration,
+                            title = stringResource(R.string.min, duration),
                             icon = painterResource(com.baghdad.design_system.R.drawable.ic_time_oclock),
                             tint = Theme.color.hint
                         )

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/EpisodesCard.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/EpisodesCard.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.baghdad.design_system.component.CircleDot
 import com.baghdad.design_system.component.LabeledIconRow
@@ -63,9 +64,12 @@ fun EpisodeCard(
             )
             Text(
                 text = episodeName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 style = Theme.typography.label.small,
                 color = Theme.color.hint
             )
+
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -77,25 +81,33 @@ fun EpisodeCard(
                     tint = Theme.color.yellowAccent
                 )
 
-                CircleDot(
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                )
-                LabeledIconRow(
-                    title = duration,
-                    icon = painterResource(com.baghdad.design_system.R.drawable.ic_time_oclock),
-                    tint = Theme.color.hint
-                )
+                if (duration[0] != '0') {
+                    Row {
+                        CircleDot(
+                            modifier = Modifier
+                                .align(Alignment.CenterVertically)
+                        )
+                        LabeledIconRow(
+                            title = duration,
+                            icon = painterResource(com.baghdad.design_system.R.drawable.ic_time_oclock),
+                            tint = Theme.color.hint
+                        )
+                    }
+                }
 
-                CircleDot(
-                    modifier = Modifier
-                        .align(Alignment.CenterVertically)
-                )
-                Text(
-                    text = releaseDate,
-                    style = Theme.typography.label.small,
-                    color = Theme.color.hint
-                )
+                if (releaseDate != "1 Jan 0001") {
+                    Row {
+                        CircleDot(
+                            modifier = Modifier
+                                .align(Alignment.CenterVertically)
+                        )
+                        Text(
+                            text = releaseDate,
+                            style = Theme.typography.label.small,
+                            color = Theme.color.hint
+                        )
+                    }
+                }
             }
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/TvShowDetailsCard.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/component/TvShowDetailsCard.kt
@@ -62,15 +62,17 @@ fun TvShowDetailsCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 genres.forEachIndexed { index, genre ->
-                    Text(
-                        text = genre.name,
-                        style = Theme.typography.label.small,
-                        color = Theme.color.body,
-                        modifier = Modifier
-                            .noRippleClickable { onGenreClick(genre.id) }
-                    )
-                    if (index < genres.size - 1) {
-                        CircleDot(modifier = Modifier.align(Alignment.CenterVertically))
+                    Row {
+                        if (index > 0) {
+                            CircleDot(modifier = Modifier.align(Alignment.CenterVertically))
+                        }
+                        Text(
+                            text = genre.name,
+                            style = Theme.typography.label.small,
+                            color = Theme.color.body,
+                            modifier = Modifier
+                                .noRippleClickable { onGenreClick(genre.id) }
+                        )
                     }
                 }
             }
@@ -98,7 +100,7 @@ fun TvShowDetailsCard(
 
             CircleDot()
             LabeledIconRow(
-                title = seasonsCount.toString(),
+                title = "$seasonsCount " + stringResource(com.baghdad.ui.R.string.season),
                 icon = painterResource(R.drawable.ic_tv),
             )
         }

--- a/ui/src/main/res/values-ar/strings.xml
+++ b/ui/src/main/res/values-ar/strings.xml
@@ -91,5 +91,6 @@
     <string name="password_reset_main_page_header">اعادة تعيين كلمة المرور</string>
     <string name="sign_up_for_an_account">سجّل للحصول على حساب</string>
     <string name="login_to_your_account_success_message">سجل الدخول لحسابك</string>
+    <string name="min">%1$s دقيقة</string>
 
 </resources>

--- a/ui/src/main/res/values-ar/strings.xml
+++ b/ui/src/main/res/values-ar/strings.xml
@@ -83,7 +83,7 @@
     <string name="trending_people">الممثلون الرائجون</string>
 
     <string name="episodes">عدد الحلقات %1$d </string>
-    <string name="s"> الموسم</string>
+    <string name="s"> الموسم </string>
     <string name="automatically_redirecting_to_login">سيتم توجيهك تلقائيا لتسجيل الدخول في ٥ ثواني …</string>
     <string name="oops_we_can_t_find_the_page">Oops! We can\'t find the page you\'re looking for</string>
     <string name="there_was_a_problem">There was a problem</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -88,5 +88,6 @@
     <string name="password_reset_success_message">Password Reset</string>
     <string name="password_reset_main_page_header">Reset password</string>
     <string name="sign_up_for_an_account">Sign up for an account</string>
-    <string name="login_to_your_account_success_message">Login to your account</string>x
+    <string name="login_to_your_account_success_message">Login to your account</string>
+    <string name="min">%1$s min</string>x
 </resources>

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/topRating/TopRatingViewModel.kt
@@ -93,10 +93,6 @@ class TopRatingViewModel(
     }
 
     override fun onSaveTvShowClick(tvShowId: Long) {
-        updateState {
-            it.copy(
-            )
-        }
 
         showSnackBar(
             message = SearchSnackBarMessage.SavedItemSuccessfully,
@@ -105,10 +101,6 @@ class TopRatingViewModel(
     }
 
     override fun onSaveMovieClick(movieId: Long) {
-        updateState {
-            it.copy(
-            )
-        }
 
         showSnackBar(
             message = SearchSnackBarMessage.SavedItemSuccessfully,

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsMapper.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsMapper.kt
@@ -4,13 +4,14 @@ import com.baghdad.entity.media.Episode
 import com.baghdad.entity.media.Genre
 import com.baghdad.entity.media.TvShow
 import com.baghdad.entity.person.CastMember
+import com.baghdad.viewmodel.movieDetails.roundToFirstDecimal
 import com.baghdad.viewmodel.util.toDDMMMYYYYFormat
 import com.baghdad.viewmodel.util.toDDMMYYYYFormat
 
 fun TvShow.toUiState() = TvShowDetailsScreenState.TvShowInfoUiState(
     title = title,
     genres = genres.map { it.toUiState() },
-    rating = averageRating,
+    rating = averageRating.roundToFirstDecimal(),
     releaseDate = releaseDate.toDDMMYYYYFormat(),
     seasonCount = numberOfSeasons,
     overView = overview,
@@ -35,7 +36,7 @@ fun Episode.toUiState() = TvShowDetailsScreenState.EpisodeUiState(
     id = id,
     name = title,
     episodeNumber = episodeNumber,
-    rating = rating,
+    rating = rating.roundToFirstDecimal(),
     duration = duration,
     releaseDate = releasedDate.toDDMMMYYYYFormat(),
     currentSeason = currentSeason,


### PR DESCRIPTION
- Hide redundant data in the Ui that are returned from API (null duration, null released date)
- Enhance the flow row behavior in TV shows genres section and seasons episode card
- Round TV show/episode rating values to its first decimal point