### PR TITLE
Fix/#446 fix the off color that appears while scrolling in the details screen

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -120,7 +119,7 @@ fun ActorDetailsContent(
         targetValue = if (shouldShowBackground)
             Theme.color.surface
         else
-            Color.Transparent,
+            Theme.color.surface.copy(alpha = 0f),
         animationSpec = tween(
             durationMillis = 500,
             easing = FastOutSlowInEasing

--- a/ui/src/main/java/com/baghdad/ui/feature/episodeDetails/EpisodeDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/episodeDetails/EpisodeDetailsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -88,7 +87,7 @@ fun EpisodeDetailsContent(
         targetValue = if (shouldShowBackground)
             Theme.color.surface
         else
-            Color.Transparent,
+            Theme.color.surface.copy(alpha = 0f),
         animationSpec = tween(
             durationMillis = 500,
             easing = FastOutSlowInEasing

--- a/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -146,7 +145,7 @@ private fun MovieDetailsContent(
         targetValue = if (shouldShowBackground)
             Theme.color.surface
         else
-            Color.Transparent,
+            Theme.color.surface.copy(alpha = 0f),
         animationSpec = tween(
             durationMillis = 500,
             easing = FastOutSlowInEasing

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -134,7 +133,7 @@ fun TvShowDetailsContent(
         targetValue = if (shouldShowBackground)
             Theme.color.surface
         else
-            Color.Transparent,
+            Theme.color.surface.copy(alpha = 0f),
         animationSpec = tween(
             durationMillis = 500,
             easing = FastOutSlowInEasing


### PR DESCRIPTION
Fix the off color that appears behind while scrolling in the details screen

**Before:**

https://github.com/user-attachments/assets/a8ab761a-3488-4276-b1b8-990129b5836a


**After:**

https://github.com/user-attachments/assets/e277e8f3-3e89-4f02-bea0-1155ad238249

