### PR TITLE
Fix/#436 splash has light background in dark mode

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="novix_icon_foreground">#FFC65A42</color>
     <color name="novix_icon_background">#FF0D0608</color>
+    <color name="splash_background">#FF0D0608</color>
 </resources>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="Theme.Novix" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowSplashScreenBackground">@color/splash_background</item>
     </style>

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.Novix" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowSplashScreenBackground">@color/splash_background</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,4 +9,5 @@
     <color name="white">#FFFFFFFF</color>
     <color name="novix_icon_foreground">#FFF77053</color>
     <color name="novix_icon_background">#FFF7FBF2</color>
+    <color name="splash_background">#FFFCF9F5</color>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="Theme.Novix" parent="android:Theme.Material.Light.NoActionBar" />
 </resources>


### PR DESCRIPTION
- Add theme dependent splash background color for android 12+

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/1b61ec9d-fd1c-434d-86ee-90444973feed" />

<img width="270" height="585" alt="image" src="https://github.com/user-attachments/assets/489e8705-b20d-4635-a393-192eb631a594" />

