### PR TITLE
Test/#488 unit test for episode details

### DIFF
--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapperTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapperTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 class EpisodeExtensionsTest {
 
     @Test
-    fun `Given Episode with null releasedDate, When toUiState, Then should use empty string`() {
+    fun `toUiState should use empty string for releasedDate when Episode has null releasedDate`() {
         // Given
         val episode = Episode(
             id = 1L,
@@ -35,7 +35,7 @@ class EpisodeExtensionsTest {
     }
 
     @Test
-    fun `Given Episode with rating, When toUiState, Then should round to first decimal`() {
+    fun `toUiState should round rating to first decimal when Episode has rating`() {
         // Given
         val episode = Episode(
             id = 1L,
@@ -59,7 +59,7 @@ class EpisodeExtensionsTest {
     }
 
     @Test
-    fun `Given empty genres list, When toUiStates, Then should return empty list`() {
+    fun `toUiStates should return empty list when genres list is empty`() {
         // Given
         val genres = emptyList<Genre>()
 
@@ -71,7 +71,7 @@ class EpisodeExtensionsTest {
     }
 
     @Test
-    fun `Given genres list, When toUiStates, Then should map all genres correctly`() {
+    fun `toUiStates should map all genres correctly when genres list has items`() {
         // Given
         val genres = listOf(
             Genre(1L, "Action"),
@@ -89,7 +89,7 @@ class EpisodeExtensionsTest {
     }
 
     @Test
-    fun `Given CastMember, When toUiState, Then should map all fields correctly`() {
+    fun `toUiState should map all fields correctly when CastMember has complete data`() {
         // Given
         val castMember = CastMember(
             actor = Actor(
@@ -121,7 +121,7 @@ class EpisodeExtensionsTest {
     }
 
     @Test
-    fun `Given CastMember with empty fields, When toUiState, Then should handle empty values`() {
+    fun `toUiState should handle empty values when CastMember has empty fields`() {
         // Given
         val castMember = CastMember(
             actor = Actor(

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapperTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapperTest.kt
@@ -1,0 +1,154 @@
+package com.baghdad.viewmodel.episodeDetails
+
+import com.baghdad.entity.media.Episode
+import com.baghdad.entity.media.Genre
+import com.baghdad.entity.person.Actor
+import com.baghdad.entity.person.CastMember
+import com.google.common.truth.Truth.assertThat
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.Test
+
+class EpisodeExtensionsTest {
+
+    @Test
+    fun `Given Episode with null releasedDate, When toUiState, Then should use empty string`() {
+        // Given
+        val episode = Episode(
+            id = 1L,
+            title = "Test",
+            releasedDate = null,
+            episodeNumber = 1,
+            rating = 0.0,
+            duration = "",
+            currentSeason = 1,
+            overview = "",
+            headerPictures = emptyList(),
+            genres = emptyList(),
+            trailerUrl = ""
+        )
+
+        // When
+        val result = episode.toUiState()
+
+        // Then
+        assertThat(result.releasedDate).isEmpty()
+    }
+
+    @Test
+    fun `Given Episode with rating, When toUiState, Then should round to first decimal`() {
+        // Given
+        val episode = Episode(
+            id = 1L,
+            title = "Test",
+            rating = 7.349,
+            episodeNumber = 1,
+            duration = "",
+            releasedDate = null,
+            currentSeason = 1,
+            overview = "",
+            headerPictures = emptyList(),
+            genres = emptyList(),
+            trailerUrl = ""
+        )
+
+        // When
+        val result = episode.toUiState()
+
+        // Then
+        assertThat(result.rating).isWithin(0.001).of(7.3)
+    }
+
+    @Test
+    fun `Given empty genres list, When toUiStates, Then should return empty list`() {
+        // Given
+        val genres = emptyList<Genre>()
+
+        // When
+        val result = genres.toUiStates()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `Given genres list, When toUiStates, Then should map all genres correctly`() {
+        // Given
+        val genres = listOf(
+            Genre(1L, "Action"),
+            Genre(2L, "Drama")
+        )
+
+        // When
+        val result = genres.toUiStates()
+
+        // Then
+        assertThat(result).containsExactly(
+            EpisodeDetailsScreenState.CategoryUiState(1L, "Action"),
+            EpisodeDetailsScreenState.CategoryUiState(2L, "Drama")
+        ).inOrder()
+    }
+
+    @Test
+    fun `Given CastMember, When toUiState, Then should map all fields correctly`() {
+        // Given
+        val castMember = CastMember(
+            actor = Actor(
+                id = 1L,
+                name = "John Doe",
+                profilePictureURL = "profile.jpg",
+                birthDate = LocalDate(1990, 1, 1),
+                placeOfBirth = "New York",
+                deathDate = LocalDate(2020, 1, 1),
+                biography = "An actor known for his roles in various films.",
+                headerPictures = listOf("header1.jpg", "header2.jpg"),
+                department = "Acting",
+            ),
+            characterName = "Detective"
+        )
+
+        // When
+        val result = castMember.toUiState()
+
+        // Then
+        assertThat(result).isEqualTo(
+            EpisodeDetailsScreenState.GuestsOfHonerUiState(
+                id = 1L,
+                name = "John Doe",
+                profilePictureURL = "profile.jpg",
+                characterName = "Detective"
+            )
+        )
+    }
+
+    @Test
+    fun `Given CastMember with empty fields, When toUiState, Then should handle empty values`() {
+        // Given
+        val castMember = CastMember(
+            actor = Actor(
+                id = 0L,
+                name = "",
+                profilePictureURL = "",
+                birthDate = LocalDate(2023, 1, 1),
+                placeOfBirth = "",
+                deathDate = LocalDate(2023, 1, 1),
+                biography = "",
+                headerPictures = emptyList(),
+                department = ""
+            ),
+            characterName = ""
+        )
+
+        // When
+        val result = castMember.toUiState()
+
+        // Then
+        assertThat(result).isEqualTo(
+            EpisodeDetailsScreenState.GuestsOfHonerUiState(
+                id = 0L,
+                name = "",
+                profilePictureURL = "",
+                characterName = ""
+            )
+        )
+    }
+}

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenEffectTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenEffectTest.kt
@@ -1,0 +1,120 @@
+package com.baghdad.viewmodel.episodeDetails
+
+import com.baghdad.viewmodel.base.BaseUiEffect
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpisodeDetailsScreenEffectTest {
+
+    @Test
+    fun `NavigateToCategoryTvShows with same ids should be equal`() {
+        val effect1 = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID)
+        val effect2 = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID)
+
+        assertEquals(effect1, effect2)
+    }
+
+    @Test
+    fun `NavigateToCategoryTvShows copy function should work correctly`() {
+        val originalEffect = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
+        val copiedEffect = originalEffect.copy(categoryId = 456L)
+
+        Assertions.assertEquals(456L, copiedEffect.categoryId)
+        Assertions.assertEquals(123L, originalEffect.categoryId)
+    }
+
+    @Test
+    fun `NavigateToActorDetails should set id correctly`() {
+        val effect = EpisodeDetailsScreenEffect.NavigateToActorDetails(ACTOR_ID)
+
+        Assertions.assertEquals(ACTOR_ID, effect.actorId)
+    }
+
+    @Test
+    fun `NavigateToActorDetails with different ids should not be equal`() {
+        val effect1 = EpisodeDetailsScreenEffect.NavigateToActorDetails(123L)
+        val effect2 = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
+
+        assertNotEquals(effect1, effect2)
+    }
+
+    @Test
+    fun `NavigateToActorDetails copy function should work correctly`() {
+        val originalEffect = EpisodeDetailsScreenEffect.NavigateToActorDetails(123L)
+        val copiedEffect = originalEffect.copy(actorId = 456L)
+
+        assertEquals(456L, copiedEffect.actorId)
+        assertEquals(123L, originalEffect.actorId)
+    }
+
+    @Test
+    fun `NavigateBack should be instance of EpisodeDetailsScreenEffect`() {
+        val effect = EpisodeDetailsScreenEffect.NavigateBack
+        assertTrue(effect is EpisodeDetailsScreenEffect)
+    }
+
+    @Test
+    fun `NavigateBack should be instance of BaseUiEffect`() {
+        val effect = EpisodeDetailsScreenEffect.NavigateBack
+        Assertions.assertTrue(effect is BaseUiEffect)
+    }
+
+    @Test
+    fun `NavigateToLogin should be instance of EpisodeDetailsScreenEffect`() {
+        val effect = EpisodeDetailsScreenEffect.NavigateToLogin
+       assertTrue(effect is EpisodeDetailsScreenEffect)
+    }
+
+    @Test
+    fun `NavigateToLogin should be instance of BaseUiEffect`() {
+        val effect = EpisodeDetailsScreenEffect.NavigateToLogin
+        assertTrue(effect is BaseUiEffect)
+    }
+
+    @Test
+    fun `all effects should be usable in collections`() {
+        val effects = listOf<EpisodeDetailsScreenEffect>(
+            EpisodeDetailsScreenEffect.NavigateBack,
+            EpisodeDetailsScreenEffect.NavigateToLogin,
+            EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID),
+            EpisodeDetailsScreenEffect.NavigateToActorDetails(ACTOR_ID)
+        )
+
+        assertEquals(4, effects.size)
+        assertTrue(effects.all { true })
+    }
+
+    @Test
+    fun `component functions should work for data classes`() {
+        val navigateToCategory = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
+        val (categoryIdComponent) = navigateToCategory
+        Assertions.assertEquals(123L, categoryIdComponent)
+
+        val navigateToActor = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
+        val (actorIdComponent) = navigateToActor
+        Assertions.assertEquals(456L, actorIdComponent)
+    }
+
+    @Test
+    fun `toString should work correctly for all effects`() {
+        val navigateToCategory = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
+        val navigateBack = EpisodeDetailsScreenEffect.NavigateBack
+        val navigateToLogin = EpisodeDetailsScreenEffect.NavigateToLogin
+        val navigateToActor = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
+
+        assertTrue(navigateToCategory.toString().contains("NavigateToCategoryTvShows"))
+        assertTrue(navigateToCategory.toString().contains("123"))
+        assertEquals("NavigateBack", navigateBack.toString())
+        assertEquals("NavigateToLogin", navigateToLogin.toString())
+        assertTrue(navigateToActor.toString().contains("NavigateToActorDetails"))
+        assertTrue(navigateToActor.toString().contains("456"))
+    }
+
+    private companion object {
+        const val CATEGORY_ID = 123L
+        const val ACTOR_ID = 456L
+    }
+}

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenEffectTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenEffectTest.kt
@@ -1,116 +1,113 @@
 package com.baghdad.viewmodel.episodeDetails
 
 import com.baghdad.viewmodel.base.BaseUiEffect
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class EpisodeDetailsScreenEffectTest {
 
     @Test
-    fun `NavigateToCategoryTvShows with same ids should be equal`() {
+    fun `NavigateToCategoryTvShows should be equal when ids are same`() {
         val effect1 = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID)
         val effect2 = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID)
 
-        assertEquals(effect1, effect2)
+        assertThat(effect1).isEqualTo(effect2)
     }
 
     @Test
-    fun `NavigateToCategoryTvShows copy function should work correctly`() {
+    fun `NavigateToCategoryTvShows should create new instance with updated id when copy is called`() {
         val originalEffect = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
         val copiedEffect = originalEffect.copy(categoryId = 456L)
 
-        Assertions.assertEquals(456L, copiedEffect.categoryId)
-        Assertions.assertEquals(123L, originalEffect.categoryId)
+        assertThat(copiedEffect.categoryId).isEqualTo(456L)
+        assertThat(originalEffect.categoryId).isEqualTo(123L)
     }
 
     @Test
-    fun `NavigateToActorDetails should set id correctly`() {
+    fun `NavigateToActorDetails should store actorId correctly when created`() {
         val effect = EpisodeDetailsScreenEffect.NavigateToActorDetails(ACTOR_ID)
 
-        Assertions.assertEquals(ACTOR_ID, effect.actorId)
+        assertThat(effect.actorId).isEqualTo(ACTOR_ID)
     }
 
     @Test
-    fun `NavigateToActorDetails with different ids should not be equal`() {
+    fun `NavigateToActorDetails should not be equal when actorIds are different`() {
         val effect1 = EpisodeDetailsScreenEffect.NavigateToActorDetails(123L)
         val effect2 = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
 
-        assertNotEquals(effect1, effect2)
+        assertThat(effect1).isNotEqualTo(effect2)
     }
 
     @Test
-    fun `NavigateToActorDetails copy function should work correctly`() {
+    fun `NavigateToActorDetails should create new instance with updated id when copy is called`() {
         val originalEffect = EpisodeDetailsScreenEffect.NavigateToActorDetails(123L)
         val copiedEffect = originalEffect.copy(actorId = 456L)
 
-        assertEquals(456L, copiedEffect.actorId)
-        assertEquals(123L, originalEffect.actorId)
+        assertThat(copiedEffect.actorId).isEqualTo(456L)
+        assertThat(originalEffect.actorId).isEqualTo(123L)
     }
 
     @Test
-    fun `NavigateBack should be instance of EpisodeDetailsScreenEffect`() {
+    fun `NavigateBack should be instance of EpisodeDetailsScreenEffect when created`() {
         val effect = EpisodeDetailsScreenEffect.NavigateBack
-        assertTrue(effect is EpisodeDetailsScreenEffect)
+        assertThat(effect).isInstanceOf(EpisodeDetailsScreenEffect::class.java)
     }
 
     @Test
-    fun `NavigateBack should be instance of BaseUiEffect`() {
+    fun `NavigateBack should be instance of BaseUiEffect when created`() {
         val effect = EpisodeDetailsScreenEffect.NavigateBack
-        Assertions.assertTrue(effect is BaseUiEffect)
+        assertThat(effect).isInstanceOf(BaseUiEffect::class.java)
     }
 
     @Test
-    fun `NavigateToLogin should be instance of EpisodeDetailsScreenEffect`() {
+    fun `NavigateToLogin should be instance of EpisodeDetailsScreenEffect when created`() {
         val effect = EpisodeDetailsScreenEffect.NavigateToLogin
-       assertTrue(effect is EpisodeDetailsScreenEffect)
+        assertThat(effect).isInstanceOf(EpisodeDetailsScreenEffect::class.java)
     }
 
     @Test
-    fun `NavigateToLogin should be instance of BaseUiEffect`() {
+    fun `NavigateToLogin should be instance of BaseUiEffect when created`() {
         val effect = EpisodeDetailsScreenEffect.NavigateToLogin
-        assertTrue(effect is BaseUiEffect)
+        assertThat(effect).isInstanceOf(BaseUiEffect::class.java)
     }
 
     @Test
-    fun `all effects should be usable in collections`() {
-        val effects = listOf<EpisodeDetailsScreenEffect>(
+    fun `all effects should be usable in collections when added`() {
+        val effects = listOf(
             EpisodeDetailsScreenEffect.NavigateBack,
             EpisodeDetailsScreenEffect.NavigateToLogin,
             EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(CATEGORY_ID),
             EpisodeDetailsScreenEffect.NavigateToActorDetails(ACTOR_ID)
         )
 
-        assertEquals(4, effects.size)
-        assertTrue(effects.all { true })
+        assertThat(effects).hasSize(4)
+        assertThat(effects).isNotEmpty()
     }
 
     @Test
-    fun `component functions should work for data classes`() {
+    fun `component functions should return correct values when destructuring data classes`() {
         val navigateToCategory = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
         val (categoryIdComponent) = navigateToCategory
-        Assertions.assertEquals(123L, categoryIdComponent)
+        assertThat(categoryIdComponent).isEqualTo(123L)
 
         val navigateToActor = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
         val (actorIdComponent) = navigateToActor
-        Assertions.assertEquals(456L, actorIdComponent)
+        assertThat(actorIdComponent).isEqualTo(456L)
     }
 
     @Test
-    fun `toString should work correctly for all effects`() {
+    fun `toString should include class name and id when called on effects`() {
         val navigateToCategory = EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(123L)
         val navigateBack = EpisodeDetailsScreenEffect.NavigateBack
         val navigateToLogin = EpisodeDetailsScreenEffect.NavigateToLogin
         val navigateToActor = EpisodeDetailsScreenEffect.NavigateToActorDetails(456L)
 
-        assertTrue(navigateToCategory.toString().contains("NavigateToCategoryTvShows"))
-        assertTrue(navigateToCategory.toString().contains("123"))
-        assertEquals("NavigateBack", navigateBack.toString())
-        assertEquals("NavigateToLogin", navigateToLogin.toString())
-        assertTrue(navigateToActor.toString().contains("NavigateToActorDetails"))
-        assertTrue(navigateToActor.toString().contains("456"))
+        assertThat(navigateToCategory.toString()).contains("NavigateToCategoryTvShows")
+        assertThat(navigateToCategory.toString()).contains("123")
+        assertThat(navigateBack.toString()).isEqualTo("NavigateBack")
+        assertThat(navigateToLogin.toString()).isEqualTo("NavigateToLogin")
+        assertThat(navigateToActor.toString()).contains("NavigateToActorDetails")
+        assertThat(navigateToActor.toString()).contains("456")
     }
 
     private companion object {

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 class EpisodeDetailsScreenStateTest {
 
     @Test
-    fun `default constructor should create state with default values`() {
+    fun `EpisodeDetailsScreenState should initialize with default values when default constructor is used`() {
         // When
         val state = EpisodeDetailsScreenState()
 
@@ -24,7 +24,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `constructor with all parameters should set values correctly`() {
+    fun `EpisodeDetailsScreenState should set all properties correctly when constructed with parameters`() {
         // Given
         val episodeUiState = createEpisodeUiState()
         val guests = listOf(createGuestOfHonor())
@@ -56,7 +56,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `isLoading should be true when either details or cast members are loading`() {
+    fun `isLoading should be true when either isEpisodeDetailsLoading or isEpisodeCastMembersLoading is true`() {
         // Given
         val loadingDetailsState = EpisodeDetailsScreenState(isEpisodeDetailsLoading = true)
         val loadingCastState = EpisodeDetailsScreenState(isEpisodeCastMembersLoading = true)
@@ -74,7 +74,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `EpisodeUiState default constructor should create with default values`() {
+    fun `EpisodeUiState should initialize with default values when default constructor is used`() {
         // When
         val episodeUiState = EpisodeDetailsScreenState.EpisodeUiState()
 
@@ -93,7 +93,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `EpisodeUiState constructor with parameters should set values correctly`() {
+    fun `EpisodeUiState should set all properties correctly when constructed with parameters`() {
         // Given
         val categories = listOf(createCategoryUiState())
         val headerPictures = listOf(HEADER_IMAGE)
@@ -128,7 +128,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `EpisodeUiState copy function should work correctly`() {
+    fun `EpisodeUiState should create new instance with updated properties when copy is called`() {
         // Given
         val original = createEpisodeUiState()
 
@@ -137,12 +137,12 @@ class EpisodeDetailsScreenStateTest {
 
         // Then
         assertThat(copied.title).isEqualTo("Copied Title")
-        assertThat(original.title).isEqualTo(EPISODE_TITLE) // Original unchanged
+        assertThat(original.title).isEqualTo(EPISODE_TITLE)
         assertThat(copied.id).isEqualTo(original.id)
     }
 
     @Test
-    fun `GuestsOfHonerUiState default constructor should create with default values`() {
+    fun `GuestsOfHonerUiState should initialize with default values when default constructor is used`() {
         // When
         val guest = EpisodeDetailsScreenState.GuestsOfHonerUiState()
 
@@ -154,7 +154,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `GuestsOfHonerUiState constructor with parameters should set values correctly`() {
+    fun `GuestsOfHonerUiState should set all properties correctly when constructed with parameters`() {
         // When
         val guest = EpisodeDetailsScreenState.GuestsOfHonerUiState(
             id = GUEST_ID,
@@ -171,7 +171,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `GuestsOfHonerUiState copy function should work correctly`() {
+    fun `GuestsOfHonerUiState should create new instance with updated properties when copy is called`() {
         // Given
         val original = createGuestOfHonor()
 
@@ -180,11 +180,11 @@ class EpisodeDetailsScreenStateTest {
 
         // Then
         assertThat(copied.name).isEqualTo("Copied Name")
-        assertThat(original.name).isEqualTo(GUEST_NAME) // Original unchanged
+        assertThat(original.name).isEqualTo(GUEST_NAME)
     }
 
     @Test
-    fun `CategoryUiState default constructor should create with default values`() {
+    fun `CategoryUiState should initialize with default values when default constructor is used`() {
         // When
         val category = EpisodeDetailsScreenState.CategoryUiState()
 
@@ -194,7 +194,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `CategoryUiState constructor with parameters should set values correctly`() {
+    fun `CategoryUiState should set all properties correctly when constructed with parameters`() {
         // When
         val category = EpisodeDetailsScreenState.CategoryUiState(
             id = CATEGORY_ID,
@@ -207,7 +207,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `CategoryUiState copy function should work correctly`() {
+    fun `CategoryUiState should create new instance with updated properties when copy is called`() {
         // Given
         val original = createCategoryUiState()
 
@@ -216,43 +216,37 @@ class EpisodeDetailsScreenStateTest {
 
         // Then
         assertThat(copied.name).isEqualTo("Copied Category")
-        assertThat(original.name).isEqualTo(CATEGORY_NAME) // Original unchanged
+        assertThat(original.name).isEqualTo(CATEGORY_NAME)
     }
 
     @Test
-    fun `AddToListBottomSheetState should work correctly`() {
-        // Default
-        val defaultState = EpisodeDetailsScreenState.AddToListBottomSheetState()
-        assertThat(defaultState.isVisible).isFalse()
-
-        // Custom
+    fun `AddToListBottomSheetState should update visibility correctly when copy is called`() {
+        // Given
         val customState = EpisodeDetailsScreenState.AddToListBottomSheetState(true)
-        assertThat(customState.isVisible).isTrue()
 
-        // Copy
+        // When
         val copied = customState.copy(isVisible = false)
+
+        // Then
         assertThat(copied.isVisible).isFalse()
-        assertThat(customState.isVisible).isTrue() // Original unchanged
+        assertThat(customState.isVisible).isTrue()
     }
 
     @Test
-    fun `RateEpisodeBottomSheetState should work correctly`() {
-        // Default
-        val defaultState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState()
-        assertThat(defaultState.isVisible).isFalse()
-
-        // Custom
+    fun `RateEpisodeBottomSheetState should update visibility correctly when copy is called`() {
+        // Given
         val customState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState(true)
-        assertThat(customState.isVisible).isTrue()
 
-        // Copy
+        // When
         val copied = customState.copy(isVisible = false)
+
+        // Then
         assertThat(copied.isVisible).isFalse()
-        assertThat(customState.isVisible).isTrue() // Original unchanged
+        assertThat(customState.isVisible).isTrue()
     }
 
     @Test
-    fun `equals should work correctly for identical states`() {
+    fun `equals should return true when comparing identical states`() {
         // Given
         val state1 = EpisodeDetailsScreenState(
             episode = createEpisodeUiState(),
@@ -269,7 +263,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `equals should work correctly for different states`() {
+    fun `equals should return false when comparing different states`() {
         // Given
         val state1 = EpisodeDetailsScreenState(episode = createEpisodeUiState())
         val state2 = EpisodeDetailsScreenState(episode = createEpisodeUiState(title = "Different"))
@@ -279,7 +273,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `state with multiple guests should preserve order`() {
+    fun `guestsOfHonor should maintain insertion order when multiple guests are added`() {
         // Given
         val guests = listOf(
             createGuestOfHonor(name = "Guest 1"),
@@ -298,7 +292,7 @@ class EpisodeDetailsScreenStateTest {
     }
 
     @Test
-    fun `state with multiple categories should preserve order`() {
+    fun `categories should maintain insertion order when multiple categories are added`() {
         // Given
         val categories = listOf(
             createCategoryUiState(name = "Category 1"),
@@ -316,7 +310,6 @@ class EpisodeDetailsScreenStateTest {
         assertThat(state.episode.categories[2].name).isEqualTo("Category 3")
     }
 
-    // Helper functions
     private fun createEpisodeUiState(
         id: Long = EPISODE_ID,
         title: String = EPISODE_TITLE,
@@ -352,6 +345,7 @@ class EpisodeDetailsScreenStateTest {
         id = id,
         name = name
     )
+
     private companion object {
         const val EPISODE_ID = 123L
         const val EPISODE_TITLE = "Test Episode"
@@ -370,5 +364,4 @@ class EpisodeDetailsScreenStateTest {
         const val CHARACTER_NAME = "Guest Star"
         const val PROFILE_PIC = "profile.jpg"
     }
-
 }

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.Test
 
 class EpisodeDetailsScreenStateTest {
 
-
-
     @Test
     fun `default constructor should create state with default values`() {
         // When

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenStateTest.kt
@@ -1,0 +1,376 @@
+package com.baghdad.viewmodel.episodeDetails
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class EpisodeDetailsScreenStateTest {
+
+
+
+    @Test
+    fun `default constructor should create state with default values`() {
+        // When
+        val state = EpisodeDetailsScreenState()
+
+        // Then
+        assertThat(state.isEpisodeDetailsLoading).isFalse()
+        assertThat(state.isEpisodeCastMembersLoading).isFalse()
+        assertThat(state.episode).isEqualTo(EpisodeDetailsScreenState.EpisodeUiState())
+        assertThat(state.guestsOfHonor).isEmpty()
+        assertThat(state.isOverviewExpanded).isFalse()
+        assertThat(state.isSavedToList).isFalse()
+        assertThat(state.isRated).isFalse()
+        assertThat(state.addToListBottomSheetState.isVisible).isFalse()
+        assertThat(state.rateEpisodeBottomSheetState.isVisible).isFalse()
+        assertThat(state.isLoading).isFalse()
+    }
+
+    @Test
+    fun `constructor with all parameters should set values correctly`() {
+        // Given
+        val episodeUiState = createEpisodeUiState()
+        val guests = listOf(createGuestOfHonor())
+
+        // When
+        val state = EpisodeDetailsScreenState(
+            isEpisodeDetailsLoading = true,
+            isEpisodeCastMembersLoading = true,
+            episode = episodeUiState,
+            guestsOfHonor = guests,
+            isOverviewExpanded = true,
+            isSavedToList = true,
+            isRated = true,
+            addToListBottomSheetState = EpisodeDetailsScreenState.AddToListBottomSheetState(true),
+            rateEpisodeBottomSheetState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState(true)
+        )
+
+        // Then
+        assertThat(state.isEpisodeDetailsLoading).isTrue()
+        assertThat(state.isEpisodeCastMembersLoading).isTrue()
+        assertThat(state.episode).isEqualTo(episodeUiState)
+        assertThat(state.guestsOfHonor).isEqualTo(guests)
+        assertThat(state.isOverviewExpanded).isTrue()
+        assertThat(state.isSavedToList).isTrue()
+        assertThat(state.isRated).isTrue()
+        assertThat(state.addToListBottomSheetState.isVisible).isTrue()
+        assertThat(state.rateEpisodeBottomSheetState.isVisible).isTrue()
+        assertThat(state.isLoading).isTrue()
+    }
+
+    @Test
+    fun `isLoading should be true when either details or cast members are loading`() {
+        // Given
+        val loadingDetailsState = EpisodeDetailsScreenState(isEpisodeDetailsLoading = true)
+        val loadingCastState = EpisodeDetailsScreenState(isEpisodeCastMembersLoading = true)
+        val loadingBothState = EpisodeDetailsScreenState(
+            isEpisodeDetailsLoading = true,
+            isEpisodeCastMembersLoading = true
+        )
+        val notLoadingState = EpisodeDetailsScreenState()
+
+        // Then
+        assertThat(loadingDetailsState.isLoading).isTrue()
+        assertThat(loadingCastState.isLoading).isTrue()
+        assertThat(loadingBothState.isLoading).isTrue()
+        assertThat(notLoadingState.isLoading).isFalse()
+    }
+
+    @Test
+    fun `EpisodeUiState default constructor should create with default values`() {
+        // When
+        val episodeUiState = EpisodeDetailsScreenState.EpisodeUiState()
+
+        // Then
+        assertThat(episodeUiState.id).isEqualTo(0L)
+        assertThat(episodeUiState.title).isEmpty()
+        assertThat(episodeUiState.episodeNumber).isEqualTo(0)
+        assertThat(episodeUiState.rating).isEqualTo(0.0)
+        assertThat(episodeUiState.trailerUrl).isEmpty()
+        assertThat(episodeUiState.duration).isEmpty()
+        assertThat(episodeUiState.releasedDate).isEmpty()
+        assertThat(episodeUiState.currentSeason).isEqualTo(0)
+        assertThat(episodeUiState.overview).isEmpty()
+        assertThat(episodeUiState.categories).isEmpty()
+        assertThat(episodeUiState.headerPictures).isEmpty()
+    }
+
+    @Test
+    fun `EpisodeUiState constructor with parameters should set values correctly`() {
+        // Given
+        val categories = listOf(createCategoryUiState())
+        val headerPictures = listOf(HEADER_IMAGE)
+
+        // When
+        val episodeUiState = EpisodeDetailsScreenState.EpisodeUiState(
+            id = EPISODE_ID,
+            title = EPISODE_TITLE,
+            episodeNumber = EPISODE_NUMBER,
+            rating = RATING,
+            trailerUrl = TRAILER_URL,
+            duration = DURATION,
+            releasedDate = RELEASE_DATE,
+            currentSeason = CURRENT_SEASON,
+            overview = OVERVIEW,
+            categories = categories,
+            headerPictures = headerPictures
+        )
+
+        // Then
+        assertThat(episodeUiState.id).isEqualTo(EPISODE_ID)
+        assertThat(episodeUiState.title).isEqualTo(EPISODE_TITLE)
+        assertThat(episodeUiState.episodeNumber).isEqualTo(EPISODE_NUMBER)
+        assertThat(episodeUiState.rating).isEqualTo(RATING)
+        assertThat(episodeUiState.trailerUrl).isEqualTo(TRAILER_URL)
+        assertThat(episodeUiState.duration).isEqualTo(DURATION)
+        assertThat(episodeUiState.releasedDate).isEqualTo(RELEASE_DATE)
+        assertThat(episodeUiState.currentSeason).isEqualTo(CURRENT_SEASON)
+        assertThat(episodeUiState.overview).isEqualTo(OVERVIEW)
+        assertThat(episodeUiState.categories).isEqualTo(categories)
+        assertThat(episodeUiState.headerPictures).isEqualTo(headerPictures)
+    }
+
+    @Test
+    fun `EpisodeUiState copy function should work correctly`() {
+        // Given
+        val original = createEpisodeUiState()
+
+        // When
+        val copied = original.copy(title = "Copied Title")
+
+        // Then
+        assertThat(copied.title).isEqualTo("Copied Title")
+        assertThat(original.title).isEqualTo(EPISODE_TITLE) // Original unchanged
+        assertThat(copied.id).isEqualTo(original.id)
+    }
+
+    @Test
+    fun `GuestsOfHonerUiState default constructor should create with default values`() {
+        // When
+        val guest = EpisodeDetailsScreenState.GuestsOfHonerUiState()
+
+        // Then
+        assertThat(guest.id).isEqualTo(0L)
+        assertThat(guest.name).isEmpty()
+        assertThat(guest.characterName).isEmpty()
+        assertThat(guest.profilePictureURL).isEmpty()
+    }
+
+    @Test
+    fun `GuestsOfHonerUiState constructor with parameters should set values correctly`() {
+        // When
+        val guest = EpisodeDetailsScreenState.GuestsOfHonerUiState(
+            id = GUEST_ID,
+            name = GUEST_NAME,
+            characterName = CHARACTER_NAME,
+            profilePictureURL = PROFILE_PIC
+        )
+
+        // Then
+        assertThat(guest.id).isEqualTo(GUEST_ID)
+        assertThat(guest.name).isEqualTo(GUEST_NAME)
+        assertThat(guest.characterName).isEqualTo(CHARACTER_NAME)
+        assertThat(guest.profilePictureURL).isEqualTo(PROFILE_PIC)
+    }
+
+    @Test
+    fun `GuestsOfHonerUiState copy function should work correctly`() {
+        // Given
+        val original = createGuestOfHonor()
+
+        // When
+        val copied = original.copy(name = "Copied Name")
+
+        // Then
+        assertThat(copied.name).isEqualTo("Copied Name")
+        assertThat(original.name).isEqualTo(GUEST_NAME) // Original unchanged
+    }
+
+    @Test
+    fun `CategoryUiState default constructor should create with default values`() {
+        // When
+        val category = EpisodeDetailsScreenState.CategoryUiState()
+
+        // Then
+        assertThat(category.id).isEqualTo(0L)
+        assertThat(category.name).isEmpty()
+    }
+
+    @Test
+    fun `CategoryUiState constructor with parameters should set values correctly`() {
+        // When
+        val category = EpisodeDetailsScreenState.CategoryUiState(
+            id = CATEGORY_ID,
+            name = CATEGORY_NAME
+        )
+
+        // Then
+        assertThat(category.id).isEqualTo(CATEGORY_ID)
+        assertThat(category.name).isEqualTo(CATEGORY_NAME)
+    }
+
+    @Test
+    fun `CategoryUiState copy function should work correctly`() {
+        // Given
+        val original = createCategoryUiState()
+
+        // When
+        val copied = original.copy(name = "Copied Category")
+
+        // Then
+        assertThat(copied.name).isEqualTo("Copied Category")
+        assertThat(original.name).isEqualTo(CATEGORY_NAME) // Original unchanged
+    }
+
+    @Test
+    fun `AddToListBottomSheetState should work correctly`() {
+        // Default
+        val defaultState = EpisodeDetailsScreenState.AddToListBottomSheetState()
+        assertThat(defaultState.isVisible).isFalse()
+
+        // Custom
+        val customState = EpisodeDetailsScreenState.AddToListBottomSheetState(true)
+        assertThat(customState.isVisible).isTrue()
+
+        // Copy
+        val copied = customState.copy(isVisible = false)
+        assertThat(copied.isVisible).isFalse()
+        assertThat(customState.isVisible).isTrue() // Original unchanged
+    }
+
+    @Test
+    fun `RateEpisodeBottomSheetState should work correctly`() {
+        // Default
+        val defaultState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState()
+        assertThat(defaultState.isVisible).isFalse()
+
+        // Custom
+        val customState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState(true)
+        assertThat(customState.isVisible).isTrue()
+
+        // Copy
+        val copied = customState.copy(isVisible = false)
+        assertThat(copied.isVisible).isFalse()
+        assertThat(customState.isVisible).isTrue() // Original unchanged
+    }
+
+    @Test
+    fun `equals should work correctly for identical states`() {
+        // Given
+        val state1 = EpisodeDetailsScreenState(
+            episode = createEpisodeUiState(),
+            guestsOfHonor = listOf(createGuestOfHonor())
+        )
+        val state2 = EpisodeDetailsScreenState(
+            episode = createEpisodeUiState(),
+            guestsOfHonor = listOf(createGuestOfHonor())
+        )
+
+        // Then
+        assertThat(state1).isEqualTo(state2)
+        assertThat(state1.hashCode()).isEqualTo(state2.hashCode())
+    }
+
+    @Test
+    fun `equals should work correctly for different states`() {
+        // Given
+        val state1 = EpisodeDetailsScreenState(episode = createEpisodeUiState())
+        val state2 = EpisodeDetailsScreenState(episode = createEpisodeUiState(title = "Different"))
+
+        // Then
+        assertThat(state1).isNotEqualTo(state2)
+    }
+
+    @Test
+    fun `state with multiple guests should preserve order`() {
+        // Given
+        val guests = listOf(
+            createGuestOfHonor(name = "Guest 1"),
+            createGuestOfHonor(name = "Guest 2"),
+            createGuestOfHonor(name = "Guest 3")
+        )
+
+        // When
+        val state = EpisodeDetailsScreenState(guestsOfHonor = guests)
+
+        // Then
+        assertThat(state.guestsOfHonor).hasSize(3)
+        assertThat(state.guestsOfHonor[0].name).isEqualTo("Guest 1")
+        assertThat(state.guestsOfHonor[1].name).isEqualTo("Guest 2")
+        assertThat(state.guestsOfHonor[2].name).isEqualTo("Guest 3")
+    }
+
+    @Test
+    fun `state with multiple categories should preserve order`() {
+        // Given
+        val categories = listOf(
+            createCategoryUiState(name = "Category 1"),
+            createCategoryUiState(name = "Category 2"),
+            createCategoryUiState(name = "Category 3")
+        )
+
+        // When
+        val state = EpisodeDetailsScreenState(episode = createEpisodeUiState(categories = categories))
+
+        // Then
+        assertThat(state.episode.categories).hasSize(3)
+        assertThat(state.episode.categories[0].name).isEqualTo("Category 1")
+        assertThat(state.episode.categories[1].name).isEqualTo("Category 2")
+        assertThat(state.episode.categories[2].name).isEqualTo("Category 3")
+    }
+
+    // Helper functions
+    private fun createEpisodeUiState(
+        id: Long = EPISODE_ID,
+        title: String = EPISODE_TITLE,
+        categories: List<EpisodeDetailsScreenState.CategoryUiState> = listOf(createCategoryUiState())
+    ) = EpisodeDetailsScreenState.EpisodeUiState(
+        id = id,
+        title = title,
+        episodeNumber = EPISODE_NUMBER,
+        rating = RATING,
+        trailerUrl = TRAILER_URL,
+        duration = DURATION,
+        releasedDate = RELEASE_DATE,
+        currentSeason = CURRENT_SEASON,
+        overview = OVERVIEW,
+        categories = categories,
+        headerPictures = listOf(HEADER_IMAGE)
+    )
+
+    private fun createGuestOfHonor(
+        id: Long = GUEST_ID,
+        name: String = GUEST_NAME
+    ) = EpisodeDetailsScreenState.GuestsOfHonerUiState(
+        id = id,
+        name = name,
+        characterName = CHARACTER_NAME,
+        profilePictureURL = PROFILE_PIC
+    )
+
+    private fun createCategoryUiState(
+        id: Long = CATEGORY_ID,
+        name: String = CATEGORY_NAME
+    ) = EpisodeDetailsScreenState.CategoryUiState(
+        id = id,
+        name = name
+    )
+    private companion object {
+        const val EPISODE_ID = 123L
+        const val EPISODE_TITLE = "Test Episode"
+        const val EPISODE_NUMBER = 1
+        const val RATING = 8.5
+        const val DURATION = "45m"
+        const val RELEASE_DATE = "2023-01-01"
+        const val CURRENT_SEASON = 1
+        const val OVERVIEW = "Test episode overview"
+        const val TRAILER_URL = "https://youtube.com/watch?v=test"
+        const val CATEGORY_ID = 28L
+        const val CATEGORY_NAME = "Action"
+        const val HEADER_IMAGE = "header1.jpg"
+        const val GUEST_ID = 456L
+        const val GUEST_NAME = "John Doe"
+        const val CHARACTER_NAME = "Guest Star"
+        const val PROFILE_PIC = "profile.jpg"
+    }
+
+}

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
@@ -1,0 +1,372 @@
+package com.baghdad.viewmodel.episodeDetails
+
+import com.baghdad.domain.usecase.episode.GetEpisodeCastMembersUseCase
+import com.baghdad.domain.usecase.episode.GetEpisodeDetailsUseCase
+import com.baghdad.entity.media.Episode
+import com.baghdad.entity.media.Genre
+import com.baghdad.entity.person.Actor
+import com.baghdad.entity.person.CastMember
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EpisodeDetailsViewModelTest {
+
+    private lateinit var getEpisodeCastMembersUseCase: GetEpisodeCastMembersUseCase
+    private lateinit var getEpisodeDetailsUseCase: GetEpisodeDetailsUseCase
+    private lateinit var episodeDetailsViewModel: EpisodeDetailsViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val tvShowId = 123L
+    private val seasonNumber = 1
+    private val episodeNumber = 1
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        getEpisodeCastMembersUseCase = mockk()
+        getEpisodeDetailsUseCase = mockk()
+
+        coEvery { getEpisodeCastMembersUseCase(any(), any(), any()) } returns createMockCastMembers()
+        coEvery { getEpisodeDetailsUseCase(any(), any(), any()) } returns createMockEpisode()
+
+        episodeDetailsViewModel = EpisodeDetailsViewModel(
+            tvShowId = tvShowId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            getEpisodeCastMembersUseCase = getEpisodeCastMembersUseCase,
+            getEpisodeDetailsUseCase = getEpisodeDetailsUseCase
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+
+    @Test
+    fun ` should send NavigateBack effect when onBackClick is clicked`() = runTest {
+        // Given
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        var receivedEffect: EpisodeDetailsScreenEffect? = null
+        val job = launch {
+            episodeDetailsViewModel.uiEffect.collect { effect ->
+                receivedEffect = effect
+            }
+        }
+        // When
+        episodeDetailsViewModel.onBackClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(EpisodeDetailsScreenEffect.NavigateBack, receivedEffect)
+        job.cancel()
+    }
+
+    @Test
+    fun `onReadMoreOverviewClick should toggle isOverviewExpanded state when click on onReadMoreOverviewClick`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Given
+        val initialState = episodeDetailsViewModel.uiState.value.isOverviewExpanded
+
+        // When
+        episodeDetailsViewModel.onReadMoreOverviewClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        val finalState = episodeDetailsViewModel.uiState.value.isOverviewExpanded
+        assertEquals(!initialState, finalState)
+    }
+
+    @Test
+    fun `should send NavigateToCategoryTvShows effect when onCategoryClick clicked`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Given
+        val categoryId = 28L
+        var receivedEffect: EpisodeDetailsScreenEffect? = null
+        val job = launch {
+            episodeDetailsViewModel.uiEffect.collect { effect ->
+                receivedEffect = effect
+            }
+        }
+        // When
+        episodeDetailsViewModel.onCategoryClick(categoryId)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(categoryId), receivedEffect)
+        job.cancel()
+    }
+
+    @Test
+    fun `should send NavigateToActorDetails effect when onGuestOfHonorClick clicked`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        // Given
+        val guestId = 456L
+        var receivedEffect: EpisodeDetailsScreenEffect? = null
+        val job = launch {
+            episodeDetailsViewModel.uiEffect.collect { effect ->
+                receivedEffect = effect
+            }
+        }
+        // When
+        episodeDetailsViewModel.onGuestOfHonorClick(guestId)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(EpisodeDetailsScreenEffect.NavigateToActorDetails(guestId), receivedEffect)
+        job.cancel()
+    }
+
+    @Test
+    fun `should show add to list bottom sheet when onSaveEpisodeClick clicked`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        episodeDetailsViewModel.onSaveEpisodeClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertTrue(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `onDismissAddToListBottomSheetClick should hide add to list bottom sheet`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        episodeDetailsViewModel.onSaveEpisodeClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        episodeDetailsViewModel.onDismissAddToListBottomSheetClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertFalse(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `should send NavigateToLogin effect when onLoginClick clicked`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Given
+        var receivedEffect: EpisodeDetailsScreenEffect? = null
+        val job = launch {
+            episodeDetailsViewModel.uiEffect.collect { effect ->
+                receivedEffect = effect
+            }
+        }
+        // When
+        episodeDetailsViewModel.onLoginClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertEquals(EpisodeDetailsScreenEffect.NavigateToLogin, receivedEffect)
+        job.cancel()
+    }
+
+    @Test
+    fun `should show rate episode bottom sheet onRateEpisodeClick clicked`() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+        // When
+        episodeDetailsViewModel.onRateEpisodeClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertTrue(episodeDetailsViewModel.uiState.value.rateEpisodeBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `should hide rate episode bottom sheet when onDismissRatingBottomSheet `() = runTest {
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // When
+        episodeDetailsViewModel.onRateEpisodeClick()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        episodeDetailsViewModel.onDismissRatingBottomSheet()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        assertFalse(episodeDetailsViewModel.uiState.value.rateEpisodeBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `failure should handle error gracefully when getEpisodeDetails`() = runTest {
+        val exception = RuntimeException()
+        coEvery { getEpisodeDetailsUseCase(any(), any(), any()) } throws exception
+
+        episodeDetailsViewModel = EpisodeDetailsViewModel(
+            tvShowId = tvShowId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            getEpisodeCastMembersUseCase = getEpisodeCastMembersUseCase,
+            getEpisodeDetailsUseCase = getEpisodeDetailsUseCase
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { getEpisodeDetailsUseCase(tvShowId, seasonNumber, episodeNumber) }
+        assertFalse(episodeDetailsViewModel.uiState.value.isEpisodeDetailsLoading)
+    }
+
+    @Test
+    fun `failure should handle error gracefully when getEpisodeCastMembers`() = runTest {
+        val exception = RuntimeException()
+        coEvery { getEpisodeCastMembersUseCase(any(), any(), any()) } throws exception
+
+        episodeDetailsViewModel = EpisodeDetailsViewModel(
+            tvShowId = tvShowId,
+            seasonNumber = seasonNumber,
+            episodeNumber = episodeNumber,
+            getEpisodeCastMembersUseCase = getEpisodeCastMembersUseCase,
+            getEpisodeDetailsUseCase = getEpisodeDetailsUseCase
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { getEpisodeCastMembersUseCase(tvShowId, seasonNumber, episodeNumber) }
+        assertFalse(episodeDetailsViewModel.uiState.value.isEpisodeCastMembersLoading)
+    }
+
+    @Test
+    fun `onPlayTrailerClick should do nothing for now`() = runTest {
+        episodeDetailsViewModel.onPlayTrailerClick()
+    }
+
+    @Test
+    fun `state should have correct initial values`() = runTest {
+        val initialState = EpisodeDetailsScreenState()
+
+        assertFalse(initialState.isEpisodeDetailsLoading)
+        assertFalse(initialState.isEpisodeCastMembersLoading)
+        assertEquals(EpisodeDetailsScreenState.EpisodeUiState(), initialState.episode)
+        assertTrue(initialState.guestsOfHonor.isEmpty())
+        assertFalse(initialState.isOverviewExpanded)
+        assertFalse(initialState.isSavedToList)
+        assertFalse(initialState.isRated)
+        assertFalse(initialState.addToListBottomSheetState.isVisible)
+        assertFalse(initialState.rateEpisodeBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `EpisodeUiState should have correct default values`() = runTest {
+        val defaultUiState = EpisodeDetailsScreenState.EpisodeUiState()
+
+        assertEquals(0L, defaultUiState.id)
+        assertEquals("", defaultUiState.title)
+        assertEquals(0, defaultUiState.episodeNumber)
+        assertEquals(0.0, defaultUiState.rating)
+        assertEquals("", defaultUiState.trailerUrl)
+        assertEquals("", defaultUiState.duration)
+        assertEquals("", defaultUiState.releasedDate)
+        assertEquals(0, defaultUiState.currentSeason)
+        assertEquals("", defaultUiState.overview)
+        assertTrue(defaultUiState.categories.isEmpty())
+        assertTrue(defaultUiState.headerPictures.isEmpty())
+    }
+
+    @Test
+    fun `GuestsOfHonerUiState should have correct default values`() = runTest {
+        val defaultGuestState = EpisodeDetailsScreenState.GuestsOfHonerUiState()
+
+        assertEquals(0L, defaultGuestState.id)
+        assertEquals("", defaultGuestState.name)
+        assertEquals("", defaultGuestState.characterName)
+        assertEquals("", defaultGuestState.profilePictureURL)
+    }
+
+    @Test
+    fun `CategoryUiState should have correct default values`() = runTest {
+        val defaultCategoryState = EpisodeDetailsScreenState.CategoryUiState()
+
+        assertEquals(0L, defaultCategoryState.id)
+        assertEquals("", defaultCategoryState.name)
+    }
+
+    @Test
+    fun `AddToListBottomSheetState should have correct default values`() = runTest {
+        val defaultBottomSheetState = EpisodeDetailsScreenState.AddToListBottomSheetState()
+        assertFalse(defaultBottomSheetState.isVisible)
+    }
+
+    @Test
+    fun `RateEpisodeBottomSheetState should have correct default values`() = runTest {
+        val defaultRateState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState()
+        assertFalse(defaultRateState.isVisible)
+    }
+
+    companion object {
+        private fun createMockEpisode() = Episode(
+            id = 123L,
+            title = "Test Episode",
+            episodeNumber = 1,
+            rating = 8.5,
+            duration = "45m",
+            releasedDate = LocalDate.parse("2023-01-01"),
+            trailerUrl = "https://youtube.com/watch?v=test",
+            currentSeason = 1,
+            overview = "Test episode overview",
+            genres = listOf(
+                Genre(28L, "Action"),
+                Genre(35L, "Comedy")
+            ),
+            headerPictures = listOf(
+                "/header1.jpg",
+                "/header2.jpg"
+            )
+        )
+
+        private fun createMockCastMembers() = listOf(
+            CastMember(
+                actor = Actor(
+                    id = 1L,
+                    name = "John Doe",
+                    profilePictureURL = "/john_doe.jpg",
+                    birthDate = LocalDate.parse("1980-01-01"),
+                    placeOfBirth = "New York, USA",
+                    deathDate = null,
+                    biography = "Famous actor",
+                    headerPictures = listOf("/header1.jpg"),
+                    department = "Acting"
+                ),
+                characterName = "Guest Star"
+            ),
+            CastMember(
+                actor = Actor(
+                    id = 2L,
+                    name = "Jane Smith",
+                    profilePictureURL = "/jane_smith.jpg",
+                    birthDate = LocalDate.parse("1985-01-01"),
+                    placeOfBirth = "Los Angeles, USA",
+                    deathDate = null,
+                    biography = "Talented actress",
+                    headerPictures = listOf("/header2.jpg"),
+                    department = "Acting"
+                ),
+                characterName = "Special Guest"
+            )
+        )
+    }
+
+}

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.baghdad.entity.media.Episode
 import com.baghdad.entity.media.Genre
 import com.baghdad.entity.person.Actor
 import com.baghdad.entity.person.CastMember
+import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -18,15 +19,11 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class EpisodeDetailsViewModelTest {
-
 
     @BeforeEach
     fun setUp() {
@@ -52,29 +49,28 @@ class EpisodeDetailsViewModelTest {
         Dispatchers.resetMain()
     }
 
-
     @Test
-    fun ` should send NavigateBack effect when onBackClick is clicked`() = runTest {
+    fun `onBackClick should emit NavigateBack effect when called`() = runTest {
         // Given
         testDispatcher.scheduler.advanceUntilIdle()
-
         var receivedEffect: EpisodeDetailsScreenEffect? = null
         val job = launch {
             episodeDetailsViewModel.uiEffect.collect { effect ->
                 receivedEffect = effect
             }
         }
+
         // When
         episodeDetailsViewModel.onBackClick()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertEquals(EpisodeDetailsScreenEffect.NavigateBack, receivedEffect)
+        assertThat(receivedEffect).isEqualTo(EpisodeDetailsScreenEffect.NavigateBack)
         job.cancel()
     }
 
     @Test
-    fun `onReadMoreOverviewClick should toggle isOverviewExpanded state when click on onReadMoreOverviewClick`() = runTest {
+    fun `onReadMoreOverviewClick should toggle isOverviewExpanded state when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Given
@@ -85,12 +81,11 @@ class EpisodeDetailsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        val finalState = episodeDetailsViewModel.uiState.value.isOverviewExpanded
-        assertEquals(!initialState, finalState)
+        assertThat(episodeDetailsViewModel.uiState.value.isOverviewExpanded).isEqualTo(!initialState)
     }
 
     @Test
-    fun `should send NavigateToCategoryTvShows effect when onCategoryClick clicked`() = runTest {
+    fun `onCategoryClick should emit NavigateToCategoryTvShows effect with correct id when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Given
@@ -101,18 +96,20 @@ class EpisodeDetailsViewModelTest {
                 receivedEffect = effect
             }
         }
+
         // When
         episodeDetailsViewModel.onCategoryClick(categoryId)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertEquals(EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(categoryId), receivedEffect)
+        assertThat(receivedEffect).isEqualTo(EpisodeDetailsScreenEffect.NavigateToCategoryTvShows(categoryId))
         job.cancel()
     }
 
     @Test
-    fun `should send NavigateToActorDetails effect when onGuestOfHonorClick clicked`() = runTest {
+    fun `onGuestOfHonorClick should emit NavigateToActorDetails effect with correct id when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
+
         // Given
         val guestId = 456L
         var receivedEffect: EpisodeDetailsScreenEffect? = null
@@ -121,17 +118,18 @@ class EpisodeDetailsViewModelTest {
                 receivedEffect = effect
             }
         }
+
         // When
         episodeDetailsViewModel.onGuestOfHonorClick(guestId)
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertEquals(EpisodeDetailsScreenEffect.NavigateToActorDetails(guestId), receivedEffect)
+        assertThat(receivedEffect).isEqualTo(EpisodeDetailsScreenEffect.NavigateToActorDetails(guestId))
         job.cancel()
     }
 
     @Test
-    fun `should show add to list bottom sheet when onSaveEpisodeClick clicked`() = runTest {
+    fun `onSaveEpisodeClick should show addToListBottomSheet when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // When
@@ -139,26 +137,27 @@ class EpisodeDetailsViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertTrue(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible)
+        assertThat(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible).isTrue()
     }
 
     @Test
-    fun `onDismissAddToListBottomSheetClick should hide add to list bottom sheet`() = runTest {
+    fun `onDismissAddToListBottomSheetClick should hide addToListBottomSheet when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // When
+        // Given
         episodeDetailsViewModel.onSaveEpisodeClick()
         testDispatcher.scheduler.advanceUntilIdle()
 
+        // When
         episodeDetailsViewModel.onDismissAddToListBottomSheetClick()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertFalse(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible)
+        assertThat(episodeDetailsViewModel.uiState.value.addToListBottomSheetState.isVisible).isFalse()
     }
 
     @Test
-    fun `should send NavigateToLogin effect when onLoginClick clicked`() = runTest {
+    fun `onLoginClick should emit NavigateToLogin effect when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Given
@@ -168,43 +167,35 @@ class EpisodeDetailsViewModelTest {
                 receivedEffect = effect
             }
         }
+
         // When
         episodeDetailsViewModel.onLoginClick()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertEquals(EpisodeDetailsScreenEffect.NavigateToLogin, receivedEffect)
+        assertThat(receivedEffect).isEqualTo(EpisodeDetailsScreenEffect.NavigateToLogin)
         job.cancel()
     }
 
     @Test
-    fun `should show rate episode bottom sheet onRateEpisodeClick clicked`() = runTest {
+    fun `onDismissRatingBottomSheet should hide rateEpisodeBottomSheet when called`() = runTest {
         testDispatcher.scheduler.advanceUntilIdle()
-        // When
+
+        // Given
         episodeDetailsViewModel.onRateEpisodeClick()
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Then
-        assertTrue(episodeDetailsViewModel.uiState.value.rateEpisodeBottomSheetState.isVisible)
-    }
-
-    @Test
-    fun `should hide rate episode bottom sheet when onDismissRatingBottomSheet `() = runTest {
-        testDispatcher.scheduler.advanceUntilIdle()
-
         // When
-        episodeDetailsViewModel.onRateEpisodeClick()
-        testDispatcher.scheduler.advanceUntilIdle()
-
         episodeDetailsViewModel.onDismissRatingBottomSheet()
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Then
-        assertFalse(episodeDetailsViewModel.uiState.value.rateEpisodeBottomSheetState.isVisible)
+        assertThat(episodeDetailsViewModel.uiState.value.rateEpisodeBottomSheetState.isVisible).isFalse()
     }
 
     @Test
-    fun `failure should handle error gracefully when getEpisodeDetails`() = runTest {
+    fun `getEpisodeDetails should handle errors gracefully when exception occurs`() = runTest {
+        // Given
         val exception = RuntimeException()
         coEvery { getEpisodeDetailsUseCase(any(), any(), any()) } throws exception
 
@@ -216,14 +207,17 @@ class EpisodeDetailsViewModelTest {
             getEpisodeDetailsUseCase = getEpisodeDetailsUseCase
         )
 
+        // When
         testDispatcher.scheduler.advanceUntilIdle()
 
+        // Then
         coVerify { getEpisodeDetailsUseCase(tvShowId, seasonNumber, episodeNumber) }
-        assertFalse(episodeDetailsViewModel.uiState.value.isEpisodeDetailsLoading)
+        assertThat(episodeDetailsViewModel.uiState.value.isEpisodeDetailsLoading).isFalse()
     }
 
     @Test
-    fun `failure should handle error gracefully when getEpisodeCastMembers`() = runTest {
+    fun `getEpisodeCastMembers should handle errors gracefully when exception occurs`() = runTest {
+        // Given
         val exception = RuntimeException()
         coEvery { getEpisodeCastMembersUseCase(any(), any(), any()) } throws exception
 
@@ -235,77 +229,95 @@ class EpisodeDetailsViewModelTest {
             getEpisodeDetailsUseCase = getEpisodeDetailsUseCase
         )
 
+        // When
         testDispatcher.scheduler.advanceUntilIdle()
 
+        // Then
         coVerify { getEpisodeCastMembersUseCase(tvShowId, seasonNumber, episodeNumber) }
-        assertFalse(episodeDetailsViewModel.uiState.value.isEpisodeCastMembersLoading)
+        assertThat(episodeDetailsViewModel.uiState.value.isEpisodeCastMembersLoading).isFalse()
     }
 
     @Test
-    fun `onPlayTrailerClick should do nothing for now`() = runTest {
+    fun `onPlayTrailerClick should do nothing when called`() = runTest {
+        // When
         episodeDetailsViewModel.onPlayTrailerClick()
+
     }
 
     @Test
-    fun `state should have correct initial values`() = runTest {
+    fun `uiState should have correct default values when initialized`() = runTest {
+        // Given
         val initialState = EpisodeDetailsScreenState()
 
-        assertFalse(initialState.isEpisodeDetailsLoading)
-        assertFalse(initialState.isEpisodeCastMembersLoading)
-        assertEquals(EpisodeDetailsScreenState.EpisodeUiState(), initialState.episode)
-        assertTrue(initialState.guestsOfHonor.isEmpty())
-        assertFalse(initialState.isOverviewExpanded)
-        assertFalse(initialState.isSavedToList)
-        assertFalse(initialState.isRated)
-        assertFalse(initialState.addToListBottomSheetState.isVisible)
-        assertFalse(initialState.rateEpisodeBottomSheetState.isVisible)
+        // Then
+        assertThat(initialState.isEpisodeDetailsLoading).isFalse()
+        assertThat(initialState.isEpisodeCastMembersLoading).isFalse()
+        assertThat(initialState.episode).isEqualTo(EpisodeDetailsScreenState.EpisodeUiState())
+        assertThat(initialState.guestsOfHonor).isEmpty()
+        assertThat(initialState.isOverviewExpanded).isFalse()
+        assertThat(initialState.isSavedToList).isFalse()
+        assertThat(initialState.isRated).isFalse()
+        assertThat(initialState.addToListBottomSheetState.isVisible).isFalse()
+        assertThat(initialState.rateEpisodeBottomSheetState.isVisible).isFalse()
     }
 
     @Test
-    fun `EpisodeUiState should have correct default values`() = runTest {
+    fun `EpisodeUiState should have correct default values when initialized`() = runTest {
+        // Given
         val defaultUiState = EpisodeDetailsScreenState.EpisodeUiState()
 
-        assertEquals(0L, defaultUiState.id)
-        assertEquals("", defaultUiState.title)
-        assertEquals(0, defaultUiState.episodeNumber)
-        assertEquals(0.0, defaultUiState.rating)
-        assertEquals("", defaultUiState.trailerUrl)
-        assertEquals("", defaultUiState.duration)
-        assertEquals("", defaultUiState.releasedDate)
-        assertEquals(0, defaultUiState.currentSeason)
-        assertEquals("", defaultUiState.overview)
-        assertTrue(defaultUiState.categories.isEmpty())
-        assertTrue(defaultUiState.headerPictures.isEmpty())
+        // Then
+        assertThat(defaultUiState.id).isEqualTo(0L)
+        assertThat(defaultUiState.title).isEmpty()
+        assertThat(defaultUiState.episodeNumber).isEqualTo(0)
+        assertThat(defaultUiState.rating).isEqualTo(0.0)
+        assertThat(defaultUiState.trailerUrl).isEmpty()
+        assertThat(defaultUiState.duration).isEmpty()
+        assertThat(defaultUiState.releasedDate).isEmpty()
+        assertThat(defaultUiState.currentSeason).isEqualTo(0)
+        assertThat(defaultUiState.overview).isEmpty()
+        assertThat(defaultUiState.categories).isEmpty()
+        assertThat(defaultUiState.headerPictures).isEmpty()
     }
 
     @Test
-    fun `GuestsOfHonerUiState should have correct default values`() = runTest {
+    fun `GuestsOfHonerUiState should have correct default values when initialized`() = runTest {
+        // Given
         val defaultGuestState = EpisodeDetailsScreenState.GuestsOfHonerUiState()
 
-        assertEquals(0L, defaultGuestState.id)
-        assertEquals("", defaultGuestState.name)
-        assertEquals("", defaultGuestState.characterName)
-        assertEquals("", defaultGuestState.profilePictureURL)
+        // Then
+        assertThat(defaultGuestState.id).isEqualTo(0L)
+        assertThat(defaultGuestState.name).isEmpty()
+        assertThat(defaultGuestState.characterName).isEmpty()
+        assertThat(defaultGuestState.profilePictureURL).isEmpty()
     }
 
     @Test
-    fun `CategoryUiState should have correct default values`() = runTest {
+    fun `CategoryUiState should have correct default values when initialized`() = runTest {
+        // Given
         val defaultCategoryState = EpisodeDetailsScreenState.CategoryUiState()
 
-        assertEquals(0L, defaultCategoryState.id)
-        assertEquals("", defaultCategoryState.name)
+        // Then
+        assertThat(defaultCategoryState.id).isEqualTo(0L)
+        assertThat(defaultCategoryState.name).isEmpty()
     }
 
     @Test
-    fun `AddToListBottomSheetState should have correct default values`() = runTest {
+    fun `AddToListBottomSheetState should have correct default values when initialized`() = runTest {
+        // Given
         val defaultBottomSheetState = EpisodeDetailsScreenState.AddToListBottomSheetState()
-        assertFalse(defaultBottomSheetState.isVisible)
+
+        // Then
+        assertThat(defaultBottomSheetState.isVisible).isFalse()
     }
 
     @Test
-    fun `RateEpisodeBottomSheetState should have correct default values`() = runTest {
+    fun `RateEpisodeBottomSheetState should have correct default values when initialized`() = runTest {
+        // Given
         val defaultRateState = EpisodeDetailsScreenState.RateEpisodeBottomSheetState()
-        assertFalse(defaultRateState.isVisible)
+
+        // Then
+        assertThat(defaultRateState.isVisible).isFalse()
     }
 
     companion object {
@@ -369,6 +381,4 @@ class EpisodeDetailsViewModelTest {
     private val tvShowId = 123L
     private val seasonNumber = 1
     private val episodeNumber = 1
-
-
 }

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModelTest.kt
@@ -27,14 +27,6 @@ import org.junit.jupiter.api.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class EpisodeDetailsViewModelTest {
 
-    private lateinit var getEpisodeCastMembersUseCase: GetEpisodeCastMembersUseCase
-    private lateinit var getEpisodeDetailsUseCase: GetEpisodeDetailsUseCase
-    private lateinit var episodeDetailsViewModel: EpisodeDetailsViewModel
-
-    private val testDispatcher = StandardTestDispatcher()
-    private val tvShowId = 123L
-    private val seasonNumber = 1
-    private val episodeNumber = 1
 
     @BeforeEach
     fun setUp() {
@@ -368,5 +360,15 @@ class EpisodeDetailsViewModelTest {
             )
         )
     }
+
+    private lateinit var getEpisodeCastMembersUseCase: GetEpisodeCastMembersUseCase
+    private lateinit var getEpisodeDetailsUseCase: GetEpisodeDetailsUseCase
+    private lateinit var episodeDetailsViewModel: EpisodeDetailsViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val tvShowId = 123L
+    private val seasonNumber = 1
+    private val episodeNumber = 1
+
 
 }

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/movieDetils/MovieDetailsViewModelTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/movieDetils/MovieDetailsViewModelTest.kt
@@ -87,7 +87,7 @@ class MovieDetailsViewModelTest {
         assertEquals("Test Movie", currentState.movieName)
         assertEquals("Test movie overview", currentState.overView)
         assertEquals(8.0, currentState.rating)
-        assertTrue(currentState.duration == "2 hr 0 min" || currentState.duration == "2h 0min")
+        assertTrue(currentState.duration ==  120)
         assertEquals("/movie_poster.jpg", currentState.posterImageURL)
         assertEquals(3, currentState.movieImages.size)
         assertEquals(2, currentState.castMembers.size)


### PR DESCRIPTION
## Description
This PR adds comprehensive unit tests for the EpisodeDetails components, including:
- `EpisodeDetailsViewModel`
- `EpisodeDetailsScreenState`
- `EpisodeDetailsScreenEffect`
- `EpisodeDetailsMapper`
 
## Related Issue 
[#488  Unit test for episode details 
](https://github.com/Baghdad-Squad/Novix/issues/488)

## Coverage Screen Shoot 

<img width="589" height="31" alt="Screenshot 2025-07-31 at 12 19 05 PM" src="https://github.com/user-attachments/assets/30a23c14-1985-4aa0-8cf5-4ffa942b4839" />
<img width="589" height="31" alt="Screenshot 2025-07-31 at 12 18 49 PM" src="https://github.com/user-attachments/assets/059b7e44-52f2-4ac8-b76a-1a906b7662b6" />
<img width="589" height="31" alt="Screenshot 2025-07-31 at 12 18 34 PM" src="https://github.com/user-attachments/assets/1e335457-dd08-4d54-8d1d-ca4be00edde5" />
<img width="589" height="31" alt="Screenshot 2025-07-31 at 12 18 00 PM" src="https://github.com/user-attachments/assets/94abbb75-c863-48f4-be4d-fb7cb342624b" />
