### PR TITLE
Feature/#528 search screen loading and retry

### DIFF
--- a/design_system/src/main/java/com/baghdad/design_system/component/button/OutlinedButton.kt
+++ b/design_system/src/main/java/com/baghdad/design_system/component/button/OutlinedButton.kt
@@ -36,7 +36,7 @@ fun OutlinedButton(
     val animatedBorderColor by animateColorAsState(
         targetValue = if (isEnabled) Theme.color.stroke else Theme.color.disable,
         animationSpec = tween(300),
-        label = stringResource(R.string.outlined_button_border_color)
+        label = stringResource(R.string.outlined_button_border_color),
     )
     OutlinedButton(
         modifier = modifier.height(48.dp),
@@ -44,39 +44,43 @@ fun OutlinedButton(
             if (!isLoading) onClick()
         },
         shape = RoundedCornerShape(12.dp),
-        colors = ButtonDefaults.outlinedButtonColors(
-            containerColor = Color.Transparent,
-            disabledContainerColor = Color.Transparent,
-            contentColor = Theme.color.primary,
-            disabledContentColor = Theme.color.disable,
-        ),
-        border = BorderStroke(
-            width = 1.dp,
-            color = animatedBorderColor
-        ),
+        colors =
+            ButtonDefaults.outlinedButtonColors(
+                containerColor = Color.Transparent,
+                disabledContainerColor = Color.Transparent,
+                contentColor = Theme.color.primary,
+                disabledContentColor = Theme.color.disable,
+            ),
+        border =
+            BorderStroke(
+                width = 1.dp,
+                color = animatedBorderColor,
+            ),
         enabled = isEnabled,
         contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp),
     ) {
         Text(
             text = label,
-            style = Theme.typography.label.large
+            style = Theme.typography.label.large,
         )
         AnimatedContent(
-            modifier = Modifier.padding(start = 8.dp),
-            targetState = isLoading
+            targetState = isLoading,
         ) { loading ->
             if (loading) {
                 StripedCircularProgressIndicator(
-                    color = LocalContentColor.current
+                    modifier = Modifier.padding(start = 8.dp),
+                    color = LocalContentColor.current,
                 )
             } else {
                 painter?.let { painter ->
                     Icon(
                         painter = painter,
                         contentDescription = stringResource(R.string.primary_button_icon),
-                        modifier = Modifier
-                            .size(20.dp)
-                    )
+                        modifier =
+                            Modifier
+                                .padding(start = 8.dp)
+                                .size(20.dp),
+                            )
                 }
             }
         }

--- a/local_datasource/src/main/java/com/baghdad/local_datasource/LocalSearchDataSourceImpl.kt
+++ b/local_datasource/src/main/java/com/baghdad/local_datasource/LocalSearchDataSourceImpl.kt
@@ -13,14 +13,17 @@ import kotlinx.coroutines.flow.map
 
 class LocalSearchDataSourceImpl(
     private val recentSearchDao: RecentSearchDao,
-    private val logger: Logger
+    private val logger: Logger,
 ) : LocalRecentSearchDataSource {
     override suspend fun addRecentSearchQuery(query: String) =
         executeWithErrorHandling(logger = logger) {
-            val newRecentSearch = RecentSearch(
-                query = query,
-            )
-            recentSearchDao.addRecentSearch(newRecentSearch)
+            val existingSearch = recentSearchDao.getRecentSearchByQuery(query)
+
+            val recentSearch =
+                existingSearch?.copy(searchedAt = System.currentTimeMillis())
+                    ?: RecentSearch(query = query)
+
+            recentSearchDao.upsertRecentSearch(recentSearch)
         }
 
     override fun getAllRecentSearches(): Flow<List<RecentSearchDto>> =

--- a/local_datasource/src/main/java/com/baghdad/local_datasource/roomDB/dao/RecentSearchDao.kt
+++ b/local_datasource/src/main/java/com/baghdad/local_datasource/roomDB/dao/RecentSearchDao.kt
@@ -10,13 +10,16 @@ import kotlinx.coroutines.flow.Flow
 interface RecentSearchDao {
 
     @Upsert
-    fun addRecentSearch(recentSearch: RecentSearch)
+    suspend fun upsertRecentSearch(recentSearch: RecentSearch)
 
     @Query("SELECT * FROM RecentSearch")
     fun getAllRecentSearch(): Flow<List<RecentSearch>>
 
     @Query("SELECT * FROM RecentSearch WHERE id = :id")
     suspend fun getRecentSearchById(id: Long): List<RecentSearch>
+
+    @Query("SELECT * FROM RecentSearch WHERE `query` = :query LIMIT 1")
+    suspend fun getRecentSearchByQuery(query: String): RecentSearch?
 
     @Query("SELECT * FROM RecentSearch ORDER BY searchedAt DESC")
     fun getLastTenRecentSearchItems(): Flow<List<RecentSearch>>

--- a/local_datasource/src/main/java/com/baghdad/local_datasource/roomDB/entity/RecentSearch.kt
+++ b/local_datasource/src/main/java/com/baghdad/local_datasource/roomDB/entity/RecentSearch.kt
@@ -1,10 +1,14 @@
 package com.baghdad.local_datasource.roomDB.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.baghdad.repository.model.RecentSearchDto
 
-@Entity(tableName = "RecentSearch")
+@Entity(
+    tableName = "RecentSearch",
+    indices = [Index(value = ["query"], unique = true)],
+)
 data class RecentSearch(
     @PrimaryKey(autoGenerate = true) val id: Long = 0L,
     val query: String,

--- a/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
@@ -122,8 +122,11 @@ fun SearchContent(
             .systemBarsPadding()
             .statusBarsPadding(),
         snackbar = {
-            SearchSnackBar(snackBarState = snackBarState)
-        }
+            SearchSnackBar(
+                snackBarState = snackBarState,
+                onActionClick = listener::onSnackBarActionLabelClick,
+            )
+        },
     ) {
         Column(
             modifier = Modifier
@@ -167,11 +170,16 @@ fun SearchContent(
 }
 
 @Composable
-private fun SearchSnackBar(snackBarState: SnackBarState) {
+private fun SearchSnackBar(
+    snackBarState: SnackBarState,
+    onActionClick: () -> Unit,
+) {
     SnackBar(
         message = stringResource(getSnackBarMessage(snackBarState.message)),
         isSuccess = snackBarState.isSuccess,
-        isVisible = snackBarState.isVisible
+        isVisible = snackBarState.isVisible,
+        actionLabel = snackBarState.actionLabelRes?.let { stringResource(it) },
+        onActionClick = onActionClick,
     )
 }
 
@@ -389,5 +397,8 @@ private fun createPreviewListener() = object : SearchInteractionListener {
     override fun onSelectedSearchTabChanged(selectedTab: SearchScreenState.SearchTab) {}
     override fun onRecentlyViewedClick(id: Long, imageUrl: String) {}
     override fun onMovieItemClick(contentId: Long, contentImageUrl: String) {}
-    override fun onTvShowItemClick(contentId: Long, contentImageUrl: String) {}
+    override fun onTvShowItemClick(contentId: Long, contentImageUrl: String,
+    ) {}
+
+    override fun onSnackBarActionLabelClick() {}
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/SearchScreen.kt
@@ -158,6 +158,8 @@ fun SearchContent(
             FilterBottomSheet(
                 isBottomSheetVisible = uiState.bottomSheetUiState.isBottomSheetVisible,
                 searchFilter = uiState.searchFilter,
+                isGenresError = uiState.searchFilter.isGenresError,
+                onReloadGenres = listener::onReloadFilterGenres,
                 onBottomSheetCloseClick = listener::onFilterCloseIconClick,
                 onClearClick = listener::onFilterClearClick,
                 onApplyClick = listener::onApplyFilterClick,
@@ -401,4 +403,6 @@ private fun createPreviewListener() = object : SearchInteractionListener {
     ) {}
 
     override fun onSnackBarActionLabelClick() {}
+
+    override fun onReloadFilterGenres() {}
 }

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/FilterBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/FilterBottomSheet.kt
@@ -29,6 +29,8 @@ fun FilterBottomSheet(
     searchFilter: SearchScreenState.SearchFilterUiState,
     onApplyClick: () -> Unit,
     onClearClick: () -> Unit,
+    isGenresError: Boolean,
+    onReloadGenres: () -> Unit,
     onBottomSheetCloseClick: () -> Unit,
     onGenreSelected: (GenreUiState) -> Unit,
     onYearRangeSelected: (ClosedFloatingPointRange<Float>) -> Unit,
@@ -62,6 +64,8 @@ fun FilterBottomSheet(
             GenresSection(
                 allGenres = searchFilter.allGenres,
                 selectedGenres = searchFilter.selectedGenres,
+                isGenresError = isGenresError,
+                onReloadGenres = onReloadGenres,
                 onGenreSelected = onGenreSelected,
                 modifier = Modifier
                     .padding(bottom = 24.dp)
@@ -105,6 +109,8 @@ private fun FilterBottomSheetPrev() {
                 onYearRangeSelected = {},
                 onGenreSelected = {},
                 onRatingChanged = {},
+                isGenresError = false,
+                onReloadGenres = {},
                 modifier = Modifier.align(Alignment.BottomCenter)
             )
         }

--- a/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/GenresSection.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/search/component/filter/GenresSection.kt
@@ -1,17 +1,25 @@
 package com.baghdad.ui.feature.search.component.filter
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.baghdad.design_system.R
 import com.baghdad.design_system.component.Chip
+import com.baghdad.design_system.component.Icon
 import com.baghdad.design_system.component.Text
+import com.baghdad.design_system.component.button.OutlinedButton
+import com.baghdad.design_system.theme.NovixTheme
 import com.baghdad.design_system.theme.Theme
 import com.baghdad.viewmodel.search.SearchScreenState.GenreUiState
 
@@ -19,35 +27,82 @@ import com.baghdad.viewmodel.search.SearchScreenState.GenreUiState
 fun GenresSection(
     allGenres: List<GenreUiState>,
     selectedGenres: List<GenreUiState>,
+    isGenresError: Boolean,
+    onReloadGenres: () -> Unit,
     onGenreSelected: (GenreUiState) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val selectedGenreNames = selectedGenres.map { it.name }
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Text(
             text = stringResource(R.string.genres),
             style = Theme.typography.title.small,
             color = Theme.color.title,
         )
-        FlowRow(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            allGenres.forEach { genre ->
-                Chip(
-                    title = genre.name,
-                    isSelected = selectedGenreNames.contains(genre.name),
-                    onClick = { onGenreSelected(genre) }
-                )
+        AnimatedContent(isGenresError) { isError ->
+            if (isError) {
+                ErrorContent { onReloadGenres() }
+            } else {
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    allGenres.forEach { genre ->
+                        Chip(
+                            title = genre.name,
+                            isSelected = selectedGenreNames.contains(genre.name),
+                            onClick = { onGenreSelected(genre) },
+                        )
+                    }
+                }
             }
         }
     }
 }
 
+@Composable
+private fun ErrorContent(
+    modifier: Modifier = Modifier,
+    onRetry: () -> Unit,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_alert),
+            tint = Theme.color.redAccent,
+            contentDescription = stringResource(com.baghdad.ui.R.string.an_error_occurred),
+            modifier = Modifier.size(56.dp),
+        )
+        Text(
+            text = stringResource(com.baghdad.ui.R.string.an_error_occurred_while_loading_genres),
+            color = Theme.color.title,
+            style = Theme.typography.body.medium,
+        )
+        OutlinedButton(
+            label = stringResource(com.baghdad.ui.R.string.retry),
+            onClick = onRetry,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorContentPreview() {
+    NovixTheme {
+        ErrorContent(onRetry = {})
+    }
+}

--- a/ui/src/main/res/values-ar/strings.xml
+++ b/ui/src/main/res/values-ar/strings.xml
@@ -110,6 +110,7 @@
     <!-- Combined duration -->
     <string name="duration_combined">%1$s  و %2$s</string>
     <string name="default_image">"الصورة الافتراضية "</string>
+    <string name="an_error_occurred_while_loading_genres">حدث خطأ أثناء تحميل الفئات</string>
 
 </resources>
 

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -101,5 +101,6 @@
     <string name="two_minute">Two minutes</string>
     <string name="minutes">Minutes</string>
     <string name="duration_combined">%1$s %2$s</string>
+    <string name="an_error_occurred_while_loading_genres">An error occurred while loading genres</string>
 
 </resources>

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/base/BaseViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/base/BaseViewModel.kt
@@ -117,7 +117,7 @@ abstract class BaseViewModel<UI_STATE : BaseUiState, UI_EFFECT : BaseUiEffect>(
     protected fun <Entity : Any, UiState : Any> collectPagingFlow(
         loadData: suspend (page: Int) -> PagedResult<Entity>,
         onInitialLoadFinished: suspend () -> Unit,
-        onError: (Throwable) -> Unit = ::handleError,
+        onInitialLoadError: (Throwable) -> Unit = ::handleError,
         pageSize: Int = 20,
         mapEntityToUiState: (Entity) -> UiState,
         onFlowCreated: (Flow<PagingData<UiState>>) -> Unit,
@@ -132,8 +132,8 @@ abstract class BaseViewModel<UI_STATE : BaseUiState, UI_EFFECT : BaseUiEffect>(
                 onInitialLoadFinished()
                 onLoadingChanged?.invoke(false)
             },
-            onError = {
-                onError(it)
+            onInitialLoadError = {
+                onInitialLoadError(it)
                 onLoadingChanged?.invoke(false)
             }
         ).map { pagingData ->

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/base/PagedResultPagingSource.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/base/PagedResultPagingSource.kt
@@ -13,57 +13,52 @@ import kotlinx.coroutines.withContext
 class PagedResultPagingSource<T : Any>(
     private val loadData: suspend (page: Int) -> PagedResult<T>,
     private val onInitialLoadFinished: suspend () -> Unit,
-    private val onError: (Throwable) -> Unit
+    private val onInitialLoadError: (Throwable) -> Unit,
 ) : PagingSource<Int, T>() {
-
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, T> {
+        val page = params.key ?: 1
         return try {
-            val page = params.key ?: 1
-            val result = withContext(Dispatchers.IO) {
-                loadData(page)
-            }
+            val result =
+                withContext(Dispatchers.IO) {
+                    loadData(page)
+                }
             if (params.key == null || page == 1) {
                 onInitialLoadFinished()
             }
             LoadResult.Page(
                 data = result.data,
                 prevKey = result.prevKey,
-                nextKey = result.nextKey
+                nextKey = result.nextKey,
             )
-
         } catch (e: Exception) {
             onInitialLoadFinished()
-            if (params.key == 1) {
-                onError(e)
+            if (page == 1) {
+                onInitialLoadError(e)
             }
             LoadResult.Error(e)
         }
     }
 
-    override fun getRefreshKey(state: PagingState<Int, T>): Int? {
-        return state.anchorPosition?.let { position ->
+    override fun getRefreshKey(state: PagingState<Int, T>): Int? =
+        state.anchorPosition?.let { position ->
             state.closestPageToPosition(position)?.nextKey?.minus(1)
         }
-    }
 }
-
 
 fun <T : Any> createPagedResultPager(
     pageSize: Int = 20,
     loadData: suspend (page: Int) -> PagedResult<T>,
     onInitialLoadFinished: suspend () -> Unit,
-    onError: (Throwable) -> Unit
-): Flow<PagingData<T>> {
-    return Pager(
-        config = PagingConfig(
-            pageSize = pageSize,
-            initialLoadSize = pageSize,
-            prefetchDistance = 4
-        ),
+    onInitialLoadError: (Throwable) -> Unit,
+): Flow<PagingData<T>> =
+    Pager(
+        config =
+            PagingConfig(
+                pageSize = pageSize,
+                initialLoadSize = pageSize,
+                prefetchDistance = 4,
+            ),
         pagingSourceFactory = {
-            PagedResultPagingSource(loadData, onInitialLoadFinished, onError)
-        }
+            PagedResultPagingSource(loadData, onInitialLoadFinished, onInitialLoadError)
+        },
     ).flow
-}
-
-

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchInteractionListener.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchInteractionListener.kt
@@ -23,4 +23,6 @@ interface SearchInteractionListener {
     fun onActorItemClick(id: Long)
 
     fun onSnackBarActionLabelClick()
+
+    fun onReloadFilterGenres()
 }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchInteractionListener.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchInteractionListener.kt
@@ -21,4 +21,6 @@ interface SearchInteractionListener {
     fun onMovieItemClick(contentId: Long, contentImageUrl: String)
     fun onTvShowItemClick(contentId: Long, contentImageUrl: String)
     fun onActorItemClick(id: Long)
+
+    fun onSnackBarActionLabelClick()
 }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchScreenState.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchScreenState.kt
@@ -71,6 +71,7 @@ data class SearchScreenState(
         val minimumYear: Int? = 1874,
         val maximumYear: Int? = 2035,
         val minimumRating: Int = 0,
+        val isGenresError: Boolean = false,
         val selectedGenres: List<GenreUiState> = emptyList(),
         val allGenres: List<GenreUiState> = emptyList()
     )

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
@@ -1,5 +1,6 @@
 package com.baghdad.viewmodel.search
 
+import com.baghdad.domain.exception.NoInternetException
 import com.baghdad.domain.model.search.RecentlyViewed
 import com.baghdad.domain.usecase.genre.GetGenresUseCase
 import com.baghdad.domain.usecase.recentlyViewed.AddRecentlyViewedUseCase
@@ -13,6 +14,7 @@ import com.baghdad.domain.usecase.search.SearchMoviesUseCase
 import com.baghdad.domain.usecase.search.SearchTvShowsUseCase
 import com.baghdad.entity.media.Genre
 import com.baghdad.entity.search.RecentSearch
+import com.baghdad.viewmodel.R
 import com.baghdad.viewmodel.base.BaseViewModel
 import com.baghdad.viewmodel.errorStates.BaseSnackBarMessage
 import com.baghdad.viewmodel.errorStates.SearchSnackBarMessage
@@ -104,6 +106,7 @@ class SearchViewModel(
                     page = page
                 )
             },
+            onInitialLoadError = ::onSearchError,
             onInitialLoadFinished = ::onFinally,
             mapEntityToUiState = { it.toMovieUI() },
             onFlowCreated = { moviesFlow ->
@@ -125,6 +128,7 @@ class SearchViewModel(
                     page = page
                 )
             },
+            onInitialLoadError = ::onSearchError,
             onInitialLoadFinished = ::onFinally,
             mapEntityToUiState = { it.toTvShowUI() },
             onFlowCreated = { tvShowsFlow -> updateState { it.copy(tvShowsFlow = tvShowsFlow) } },
@@ -142,11 +146,28 @@ class SearchViewModel(
                 )
             },
             onInitialLoadFinished = ::onFinally,
+            onInitialLoadError = ::onSearchError,
             mapEntityToUiState = { it.toActorUI() },
             onFlowCreated = { actorsFlow -> updateState { it.copy(actorsFlow = actorsFlow) } },
             onLoadingChanged = { isLoading ->
                 updateState { it.copy(isLoading = isLoading) }
             }
+        )
+    }
+
+    private fun onSearchError(throwable: Throwable) {
+        when (throwable) {
+            is NoInternetException -> showNoInternetSnackBar()
+            else -> handleError(throwable)
+        }
+    }
+
+    private fun showNoInternetSnackBar() {
+        showSnackBar(
+            message = BaseSnackBarMessage.NetworkError,
+            actionLabelRes = R.string.retry,
+            isSuccess = false,
+            durationMillis = Int.MAX_VALUE.toLong(),
         )
     }
 
@@ -540,11 +561,16 @@ class SearchViewModel(
         sendEffect(SearchScreenEffect.NavigateToActorDetails(id))
     }
 
+    override fun onSnackBarActionLabelClick() {
+        performSearchByTab(currentState.searchText)
+    }
+
     private fun onLoading() {
         updateState { it.copy(isLoading = true) }
     }
 
     private fun onFinally() {
+        hideSnackBar()
         updateState { it.copy(isLoading = false) }
     }
 

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/search/SearchViewModel.kt
@@ -36,10 +36,9 @@ class SearchViewModel(
     private val deleteRecentSearchUseCase: DeleteRecentSearchUseCase,
     private val searchMoviesUseCase: SearchMoviesUseCase,
     private val searchTvShowsUseCase: SearchTvShowsUseCase,
-    private val searchActorsUseCase: SearchActorsUseCase
+    private val searchActorsUseCase: SearchActorsUseCase,
 ) : BaseViewModel<SearchScreenState, SearchScreenEffect>(SearchScreenState()),
     SearchInteractionListener {
-
     init {
         getRecentSearches()
         getRecentViewed()
@@ -48,9 +47,7 @@ class SearchViewModel(
         observeSearchQueryChanges()
     }
 
-    override fun mapThrowableToErrorMessage(throwable: Throwable): BaseSnackBarMessage {
-        return BaseSnackBarMessage.UnknownError
-    }
+    override fun mapThrowableToErrorMessage(throwable: Throwable): BaseSnackBarMessage = BaseSnackBarMessage.UnknownError
 
     override fun onSearchTextChanged(text: String) {
         updateState { it.copy(searchText = text, isLoading = true) }
@@ -61,15 +58,14 @@ class SearchViewModel(
     }
 
     @OptIn(FlowPreview::class)
-    private fun observeSearchQueryFlow(): Flow<String> {
-        return uiState.map { it.searchText.trim() }.distinctUntilChanged()
-            .debounce(SEARCH_DEBOUNCED_DELAY)
-    }
+    private fun observeSearchQueryFlow(): Flow<String> =
+        uiState.map { it.searchText.trim() }.distinctUntilChanged().debounce(SEARCH_DEBOUNCED_DELAY)
 
     private fun observeSearchQueryChanges() {
         tryToCollect(
             flowProvider = { observeSearchQueryFlow() },
-            onNewValue = { query -> onSearchQueryChangedCollected(query) })
+            onNewValue = { query -> onSearchQueryChangedCollected(query) },
+        )
     }
 
     private fun onSearchQueryChangedCollected(query: String) {
@@ -88,7 +84,6 @@ class SearchViewModel(
         }
     }
 
-
     private fun performSearchByTab(text: String) {
         when (currentState.selectedSearchTab) {
             SearchScreenState.SearchTab.MOVIES -> searchMovies(text)
@@ -103,7 +98,7 @@ class SearchViewModel(
                 searchMoviesUseCase(
                     query = text,
                     filter = currentState.bottomSheetUiState.moviesFilter.toSearchFilter(),
-                    page = page
+                    page = page,
                 )
             },
             onInitialLoadError = ::onSearchError,
@@ -114,10 +109,9 @@ class SearchViewModel(
             },
             onLoadingChanged = { isLoading ->
                 updateState { it.copy(isLoading = isLoading) }
-            }
+            },
         )
     }
-
 
     private fun searchTvShows(text: String) {
         collectPagingFlow(
@@ -125,7 +119,7 @@ class SearchViewModel(
                 searchTvShowsUseCase(
                     query = text,
                     filter = currentState.bottomSheetUiState.tvShowsFilter.toSearchFilter(),
-                    page = page
+                    page = page,
                 )
             },
             onInitialLoadError = ::onSearchError,
@@ -134,7 +128,7 @@ class SearchViewModel(
             onFlowCreated = { tvShowsFlow -> updateState { it.copy(tvShowsFlow = tvShowsFlow) } },
             onLoadingChanged = { isLoading ->
                 updateState { it.copy(isLoading = isLoading) }
-            }
+            },
         )
     }
 
@@ -142,7 +136,8 @@ class SearchViewModel(
         collectPagingFlow(
             loadData = { page ->
                 searchActorsUseCase(
-                    query = text, page = page
+                    query = text,
+                    page = page,
                 )
             },
             onInitialLoadFinished = ::onFinally,
@@ -151,7 +146,7 @@ class SearchViewModel(
             onFlowCreated = { actorsFlow -> updateState { it.copy(actorsFlow = actorsFlow) } },
             onLoadingChanged = { isLoading ->
                 updateState { it.copy(isLoading = isLoading) }
-            }
+            },
         )
     }
 
@@ -174,7 +169,9 @@ class SearchViewModel(
     private fun clearAllPagingFlows() {
         updateState {
             it.copy(
-                moviesFlow = flowOf(), tvShowsFlow = flowOf(), actorsFlow = flowOf()
+                moviesFlow = flowOf(),
+                tvShowsFlow = flowOf(),
+                actorsFlow = flowOf(),
             )
         }
     }
@@ -189,8 +186,7 @@ class SearchViewModel(
     private fun onGetRecentViewedSuccess(recentlyViewed: List<RecentlyViewed>) {
         val recentViewedUiState = recentlyViewed.take(10).map { it.toRecentlyViewedUI() }
         updateState { searchScreenState ->
-            searchScreenState.copy(
-                recentViewed = recentViewedUiState.distinctBy { it.id })
+            searchScreenState.copy(recentViewed = recentViewedUiState.distinctBy { it.id })
         }
     }
 
@@ -204,8 +200,7 @@ class SearchViewModel(
     private fun onGetRecentSearchesSuccess(recentSearches: List<RecentSearch>) {
         val recentSearchUiState = recentSearches.take(20).map { it.toRecentSearchUI() }
         updateState { searchScreenState ->
-            searchScreenState.copy(
-                recentSearch = recentSearchUiState.distinctBy { it.query })
+            searchScreenState.copy(recentSearch = recentSearchUiState.distinctBy { it.query })
         }
     }
 
@@ -213,17 +208,37 @@ class SearchViewModel(
         tryToExecute(
             callee = { getGenresUseCase.getMovieGenres() },
             onSuccess = ::onGetMovieGenresSuccess,
-            onFinally = ::onFinally
+            onError = ::onGetMovieGenresError,
+            onFinally = ::onFinally,
         )
     }
 
     private fun onGetMovieGenresSuccess(genres: List<Genre>) {
         updateState { searchScreenState ->
             searchScreenState.copy(
-                bottomSheetUiState = searchScreenState.bottomSheetUiState.copy(
-                    moviesFilter = searchScreenState.bottomSheetUiState.moviesFilter.copy(
-                        allGenres = genres.map { it.toGenreUI() })
-                )
+                bottomSheetUiState =
+                    searchScreenState.bottomSheetUiState.copy(
+                        moviesFilter =
+                            searchScreenState.bottomSheetUiState.moviesFilter.copy(
+                                allGenres = genres.map { it.toGenreUI() },
+                                isGenresError = false,
+                            ),
+                    ),
+            )
+        }
+    }
+
+    private fun onGetMovieGenresError(throwable: Throwable) {
+        updateState { searchScreenState ->
+            searchScreenState.copy(
+                bottomSheetUiState =
+                    searchScreenState.bottomSheetUiState.copy(
+                        moviesFilter =
+                            searchScreenState.bottomSheetUiState.moviesFilter.copy(
+                                allGenres = emptyList(),
+                                isGenresError = true,
+                            ),
+                    ),
             )
         }
     }
@@ -232,18 +247,36 @@ class SearchViewModel(
         tryToExecute(
             callee = { getGenresUseCase.getTvShowGenres() },
             onSuccess = ::onGetTvShowGenresSuccess,
-            onFinally = ::onFinally
+            onFinally = ::onFinally,
         )
     }
-
 
     private fun onGetTvShowGenresSuccess(genres: List<Genre>) {
         updateState { searchScreenState ->
             searchScreenState.copy(
-                bottomSheetUiState = searchScreenState.bottomSheetUiState.copy(
-                    tvShowsFilter = searchScreenState.bottomSheetUiState.tvShowsFilter.copy(
-                        allGenres = genres.map { it.toGenreUI() })
-                )
+                bottomSheetUiState =
+                    searchScreenState.bottomSheetUiState.copy(
+                        tvShowsFilter =
+                            searchScreenState.bottomSheetUiState.tvShowsFilter.copy(
+                                allGenres = genres.map { it.toGenreUI() },
+                                isGenresError = false,
+                            ),
+                    ),
+            )
+        }
+    }
+
+    private fun onGetTvShowGenresError(throwable: Throwable) {
+        updateState { searchScreenState ->
+            searchScreenState.copy(
+                bottomSheetUiState =
+                    searchScreenState.bottomSheetUiState.copy(
+                        tvShowsFilter =
+                            searchScreenState.bottomSheetUiState.tvShowsFilter.copy(
+                                allGenres = emptyList(),
+                                isGenresError = true,
+                            ),
+                    ),
             )
         }
     }
@@ -260,19 +293,22 @@ class SearchViewModel(
     override fun onSaveRecentlyViewedClick(id: Long) {
         updateState {
             it.copy(
-                recentViewed = it.recentViewed.map { item ->
-                    if (item.id == id) item.copy(isSaved = item.isSaved.not()) else item
-                })
+                recentViewed =
+                    it.recentViewed.map { item ->
+                        if (item.id == id) item.copy(isSaved = item.isSaved.not()) else item
+                    },
+            )
         }
     }
 
     private fun onClearRecentViewedSuccess() {
         showSnackBar(
-            message = SearchSnackBarMessage.RemovedItemSuccessfully, isSuccess = true
+            message = SearchSnackBarMessage.RemovedItemSuccessfully,
+            isSuccess = true,
         )
         updateState {
             it.copy(
-                recentViewed = emptyList()
+                recentViewed = emptyList(),
             )
         }
     }
@@ -288,7 +324,8 @@ class SearchViewModel(
 
     private fun onClearRecentSearchSuccess() {
         showSnackBar(
-            message = SearchSnackBarMessage.RemovedItemSuccessfully, isSuccess = true
+            message = SearchSnackBarMessage.RemovedItemSuccessfully,
+            isSuccess = true,
         )
     }
 
@@ -303,10 +340,10 @@ class SearchViewModel(
 
     private fun onRemoveRecentSearchItemSuccess() {
         showSnackBar(
-            message = SearchSnackBarMessage.RemovedItemSuccessfully, isSuccess = true
+            message = SearchSnackBarMessage.RemovedItemSuccessfully,
+            isSuccess = true,
         )
     }
-
 
     override fun onRecentSearchItemClick(id: Long) {
         val searchText = currentState.recentSearch.find { it.id == id }?.query ?: ""
@@ -319,9 +356,10 @@ class SearchViewModel(
     override fun onFilterCloseIconClick() {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    isBottomSheetVisible = false
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        isBottomSheetVisible = false,
+                    ),
             )
         }
     }
@@ -340,12 +378,14 @@ class SearchViewModel(
     private fun resetMoviesFilter() {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    isBottomSheetVisible = false,
-                    moviesFilter = SearchScreenState.SearchFilterUiState(
-                        allGenres = currentState.bottomSheetUiState.moviesFilter.allGenres,
-                    )
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        isBottomSheetVisible = false,
+                        moviesFilter =
+                            SearchScreenState.SearchFilterUiState(
+                                allGenres = currentState.bottomSheetUiState.moviesFilter.allGenres,
+                            ),
+                    ),
             )
         }
     }
@@ -353,12 +393,14 @@ class SearchViewModel(
     private fun resetTvShowsFilter() {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    isBottomSheetVisible = false,
-                    tvShowsFilter = SearchScreenState.SearchFilterUiState(
-                        allGenres = currentState.bottomSheetUiState.tvShowsFilter.allGenres,
-                    )
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        isBottomSheetVisible = false,
+                        tvShowsFilter =
+                            SearchScreenState.SearchFilterUiState(
+                                allGenres = currentState.bottomSheetUiState.tvShowsFilter.allGenres,
+                            ),
+                    ),
             )
         }
     }
@@ -366,9 +408,10 @@ class SearchViewModel(
     override fun onApplyFilterClick() {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    isBottomSheetVisible = false
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        isBottomSheetVisible = false,
+                    ),
             )
         }
 
@@ -379,22 +422,23 @@ class SearchViewModel(
         }
     }
 
-
     override fun onFilterIconClick() {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    isBottomSheetVisible = true
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        isBottomSheetVisible = true,
+                    ),
             )
         }
 
         val isMoviesTab = currentState.selectedSearchTab == SearchScreenState.SearchTab.MOVIES
-        val isGenresEmpty = currentState.bottomSheetUiState.moviesFilter.allGenres.isEmpty()
+        val isGenresEmpty =
+            currentState.bottomSheetUiState.moviesFilter.allGenres
+                .isEmpty()
 
         if (isMoviesTab && isGenresEmpty) getMovieGenres() else getTvShowGenres()
     }
-
 
     override fun onRatingChanged(rating: Int) {
         if (currentState.selectedSearchTab == SearchScreenState.SearchTab.MOVIES) {
@@ -407,9 +451,10 @@ class SearchViewModel(
     private fun updateMoviesFilterRating(rating: Int) {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    moviesFilter = it.bottomSheetUiState.moviesFilter.copy(minimumRating = rating)
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        moviesFilter = it.bottomSheetUiState.moviesFilter.copy(minimumRating = rating),
+                    ),
             )
         }
     }
@@ -417,9 +462,10 @@ class SearchViewModel(
     private fun updateTvShowsFilterRating(rating: Int) {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    tvShowsFilter = it.bottomSheetUiState.tvShowsFilter.copy(minimumRating = rating)
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        tvShowsFilter = it.bottomSheetUiState.tvShowsFilter.copy(minimumRating = rating),
+                    ),
             )
         }
     }
@@ -435,11 +481,14 @@ class SearchViewModel(
     private fun updateMoviesFilterYearRange(range: ClosedFloatingPointRange<Float>) {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    moviesFilter = it.bottomSheetUiState.moviesFilter.copy(
-                        minimumYear = range.start.toInt(), maximumYear = range.endInclusive.toInt()
-                    )
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        moviesFilter =
+                            it.bottomSheetUiState.moviesFilter.copy(
+                                minimumYear = range.start.toInt(),
+                                maximumYear = range.endInclusive.toInt(),
+                            ),
+                    ),
             )
         }
     }
@@ -447,11 +496,14 @@ class SearchViewModel(
     private fun updateTvShowsFilterYearRange(range: ClosedFloatingPointRange<Float>) {
         updateState {
             it.copy(
-                bottomSheetUiState = it.bottomSheetUiState.copy(
-                    tvShowsFilter = it.bottomSheetUiState.tvShowsFilter.copy(
-                        minimumYear = range.start.toInt(), maximumYear = range.endInclusive.toInt()
-                    )
-                )
+                bottomSheetUiState =
+                    it.bottomSheetUiState.copy(
+                        tvShowsFilter =
+                            it.bottomSheetUiState.tvShowsFilter.copy(
+                                minimumYear = range.start.toInt(),
+                                maximumYear = range.endInclusive.toInt(),
+                            ),
+                    ),
             )
         }
     }
@@ -466,36 +518,42 @@ class SearchViewModel(
 
     private fun updateMoviesFilterGenres(selectedGenre: GenreUiState) {
         val currentGenres = currentState.bottomSheetUiState.moviesFilter.selectedGenres
-        val updatedGenres = if (currentGenres.contains(selectedGenre)) {
-            currentGenres - selectedGenre
-        } else {
-            currentGenres + selectedGenre
-        }
+        val updatedGenres =
+            if (currentGenres.contains(selectedGenre)) {
+                currentGenres - selectedGenre
+            } else {
+                currentGenres + selectedGenre
+            }
         updateState { state ->
             state.copy(
-                bottomSheetUiState = state.bottomSheetUiState.copy(
-                    moviesFilter = state.bottomSheetUiState.moviesFilter.copy(
-                        selectedGenres = updatedGenres
-                    )
-                )
+                bottomSheetUiState =
+                    state.bottomSheetUiState.copy(
+                        moviesFilter =
+                            state.bottomSheetUiState.moviesFilter.copy(
+                                selectedGenres = updatedGenres,
+                            ),
+                    ),
             )
         }
     }
 
     private fun updateTvShowsFilterGenres(selectedGenre: GenreUiState) {
         val currentGenres = currentState.bottomSheetUiState.tvShowsFilter.selectedGenres
-        val updatedGenres = if (currentGenres.contains(selectedGenre)) {
-            currentGenres - selectedGenre
-        } else {
-            currentGenres + selectedGenre
-        }
+        val updatedGenres =
+            if (currentGenres.contains(selectedGenre)) {
+                currentGenres - selectedGenre
+            } else {
+                currentGenres + selectedGenre
+            }
         updateState { state ->
             state.copy(
-                bottomSheetUiState = state.bottomSheetUiState.copy(
-                    tvShowsFilter = state.bottomSheetUiState.tvShowsFilter.copy(
-                        selectedGenres = updatedGenres
-                    )
-                )
+                bottomSheetUiState =
+                    state.bottomSheetUiState.copy(
+                        tvShowsFilter =
+                            state.bottomSheetUiState.tvShowsFilter.copy(
+                                selectedGenres = updatedGenres,
+                            ),
+                    ),
             )
         }
     }
@@ -508,7 +566,10 @@ class SearchViewModel(
         }
     }
 
-    override fun onRecentlyViewedClick(id: Long, imageUrl: String) {
+    override fun onRecentlyViewedClick(
+        id: Long,
+        imageUrl: String,
+    ) {
         val recentlyViewed = currentState.recentViewed.find { it.id == id }
         recentlyViewed?.let {
             if (it.contentType == RecentlyViewed.ContentType.MOVIE) {
@@ -520,17 +581,20 @@ class SearchViewModel(
     }
 
     override fun onMovieItemClick(
-        contentId: Long, contentImageUrl: String
+        contentId: Long,
+        contentImageUrl: String,
     ) {
         tryToExecute(
             callee = {
                 addRecentlyViewedUseCase(
-                    contentId, contentImageUrl, RecentlyViewed.ContentType.MOVIE
+                    contentId,
+                    contentImageUrl,
+                    RecentlyViewed.ContentType.MOVIE,
                 )
             },
             onSuccess = { onAddRecentlyViewedMovieSuccess(contentId) },
             onStart = ::onLoading,
-            onFinally = ::onFinally
+            onFinally = ::onFinally,
         )
     }
 
@@ -539,17 +603,20 @@ class SearchViewModel(
     }
 
     override fun onTvShowItemClick(
-        contentId: Long, contentImageUrl: String
+        contentId: Long,
+        contentImageUrl: String,
     ) {
         tryToExecute(
             callee = {
                 addRecentlyViewedUseCase(
-                    contentId, contentImageUrl, RecentlyViewed.ContentType.TV_SHOW
+                    contentId,
+                    contentImageUrl,
+                    RecentlyViewed.ContentType.TV_SHOW,
                 )
             },
             onSuccess = { onAddRecentlyViewedTvShowSuccess(contentId) },
             onStart = ::onLoading,
-            onFinally = ::onFinally
+            onFinally = ::onFinally,
         )
     }
 
@@ -563,6 +630,14 @@ class SearchViewModel(
 
     override fun onSnackBarActionLabelClick() {
         performSearchByTab(currentState.searchText)
+    }
+
+    override fun onReloadFilterGenres() {
+        if (currentState.selectedSearchTab == SearchScreenState.SearchTab.MOVIES) {
+            getMovieGenres()
+        } else {
+            getTvShowGenres()
+        }
     }
 
     private fun onLoading() {


### PR DESCRIPTION
### PR Content:
- Fixed a bug where recent searches were being re-inserted to db after clicking it.
- Added retry logic for genres in filter bottom sheet.
- Added retry logic when loading the first search page fails.

https://github.com/user-attachments/assets/0291538c-ebe6-4529-a829-4d50c96bd3a7

