### PR TITLE
Fix/#584 should add movie or tv show when open trailer not when open tv show or movie deatils 

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
@@ -177,7 +177,7 @@ private fun MovieDetailsContent(
             DetailsScreenBottomBar(
                 hasTrailer = state.movieTrailerURL.isNotBlank(),
                 onRateClicked = { listener.onStarMovieClick() },
-                onPlayTrailerClicked = { listener.onTrailerClick() },
+                onPlayTrailerClicked = { listener.onClickPlayTrailer() },
                 isRated = state.isStared,
                 isLoading = false /*TODO*/
             )

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsInteractionListener.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsInteractionListener.kt
@@ -11,6 +11,6 @@ interface MovieDetailsInteractionListener {
     fun onReviewClick(id: Long)
     fun onMovieClick(id: Long)
     fun onBackClick()
-    fun onTrailerClick()
+    fun onClickPlayTrailer()
     fun onSnackBarActionLabelClick()
 }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsViewModel.kt
@@ -123,7 +123,8 @@ class MovieDetailsViewModel(
         sendEffect(MovieDetailsEffect.NavigateBack)
     }
 
-    override fun onTrailerClick() {
+    override fun onClickPlayTrailer() {
+        addToContinueWatching()
         sendEffect(MovieDetailsEffect.OpenYoutubeLink(currentState.movieTrailerURL))
     }
 
@@ -185,7 +186,7 @@ class MovieDetailsViewModel(
             onSuccess = ::onGetMovieDetailsSuccess,
             dispatcher = ioDispatcher,
             onStart = ::onGetMovieDetailsStarted,
-            onFinally = ::onFinallyAndAddToContinueWatching,
+            onFinally = ::onFinally,
             onError = ::onError
         )
     }
@@ -290,9 +291,8 @@ class MovieDetailsViewModel(
     }
 
 
-    private fun onFinallyAndAddToContinueWatching() {
+    private fun onFinally() {
         updateState { state -> state.copy(isMovieDetailsLoading = false) }
-        addToContinueWatching()
     }
 
 

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsViewModel.kt
@@ -37,7 +37,7 @@ class TvShowDetailsViewModel(
             dispatcher = ioDispatcher,
             onSuccess = ::onGetTvShowDetailsSuccess,
             onStart = { updateState { it.copy(isTvShowDetailsLoading = true) } },
-            onFinally = ::onFinallyAndAddToContinueWatching,
+            onFinally = ::onFinally,
             onError = ::onLoadDataError
         )
     }
@@ -133,6 +133,7 @@ class TvShowDetailsViewModel(
     }
 
     override fun onClickPlayTrailer() {
+        addToContinueWatching()
         sendEffect(TvShowDetailsScreenEffect.OpenYoutubeLink(currentState.tvShowInfo.trailerURL))
     }
 
@@ -143,9 +144,8 @@ class TvShowDetailsViewModel(
     }
 
 
-    private fun onFinallyAndAddToContinueWatching() {
+    private fun onFinally() {
         updateState { it.copy(isTvShowDetailsLoading = false) }
-        addToContinueWatching()
     }
 
     private fun showNoInternetSnackBar() {

--- a/viewmodel/src/test/java/com/baghdad/viewmodel/movieDetils/MovieDetailsViewModelTest.kt
+++ b/viewmodel/src/test/java/com/baghdad/viewmodel/movieDetils/MovieDetailsViewModelTest.kt
@@ -208,7 +208,7 @@ class MovieDetailsViewModelTest {
             }
         }
         // When
-        movieDetailsViewModel.onTrailerClick()
+        movieDetailsViewModel.onClickPlayTrailer()
         advanceUntilIdle()
         // Then
         val expectedUrl = movieDetailsViewModel.uiState.value.movieTrailerURL


### PR DESCRIPTION
make continue watching add tv show or movie deatils  when open trailer video not when open tv show details or movie details 

[fix_current_watching_save_on_open_tv_show_and_move_not_when_open_trailer.webm](https://github.com/user-attachments/assets/6b5d6090-4ad4-44af-a045-a9983d59309e)
