### PR TITLE
fix/662-bottom-navigation-bar-shows-above-keyboard-in-search-screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,9 +11,11 @@
         android:fullBackupContent="@xml/backup_rules"
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
+        android:windowSoftInputMode="adjustResize"
         android:supportsRtl="true"
         android:theme="@style/Theme.Novix"
         tools:targetApi="31">
+
         <activity
             android:name="com.baghdad.novix.MainActivity"
             android:label="@string/app_name"

--- a/ui/src/main/java/com/baghdad/ui/main/MainScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/main/MainScreen.kt
@@ -10,7 +10,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -34,6 +37,7 @@ import com.baghdad.ui.navigation.bottom.rememberIsTopLevelMainRoute
 import com.baghdad.ui.navigation.route.Graph
 import com.baghdad.viewmodel.main.MainViewModel
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
@@ -50,6 +54,8 @@ fun MainScreen(
         BOTTOM_NAV_ITEMS.keys,
         TOP_LEVEL_ROUTES,
     )
+
+
 
     val selectedIndex by rememberBottomNavSelectedIndex(navBackStackEntry, BOTTOM_NAV_ITEMS.keys)
 
@@ -71,6 +77,7 @@ fun MainScreen(
                     enter = bottomSheetEnterAnimation,
                     exit = bottomSheetExitAnimation
                 ) {
+                    if(!isKeyboardOpen())
                     NovixBottomNavigationBar(
                         items = BOTTOM_NAV_ITEMS.values.toList(), onClick = { index ->
                             if (index != selectedIndex) {
@@ -105,3 +112,9 @@ private val bottomSheetExitAnimation = slideOutVertically(
     animationSpec = tween(150)
 )
 
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun isKeyboardOpen(): Boolean {
+    return WindowInsets.isImeVisible
+}


### PR DESCRIPTION
## Description 
make bottom navigation hidden when keyboard open 

## Related Issue 
[# 626 bottom navigation bar shows above keyboad in search screen
](https://github.com/Baghdad-Squad/Novix/issues/662)

##Screen Shoot

<img width="339" height="746" alt="Screenshot 2025-08-06 at 10 36 24 AM" src="https://github.com/user-attachments/assets/cf629ec8-7165-411d-a3e3-768b73e455ee" />
<img width="339" height="746" alt="Screenshot 2025-08-06 at 10 36 03 AM" src="https://github.com/user-attachments/assets/9766189e-2732-42cc-9f96-3f60752ac066" />
