### PR TITLE
fix/#704 rate bottom sheet must be disable when user hasn't rated yet

### DIFF
--- a/entity/src/main/java/com/baghdad/entity/media/TvShow.kt
+++ b/entity/src/main/java/com/baghdad/entity/media/TvShow.kt
@@ -7,7 +7,7 @@ data class TvShow(
     val title: String,
     val genres: List<Genre>,
     val averageRating: Double,
-    val userRating: Double?,
+    val userRating: Int?,
     val releaseDate: LocalDate,
     val overview: String,
     val posterImageURL: String,

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/search/TvShowSearchResponse.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/search/TvShowSearchResponse.kt
@@ -15,7 +15,6 @@ fun TvShowSearchResponse.toPagedTvShowDtos(genres: List<GenreDto>) = PagedResult
 
 private fun TvShowSearchResponse.Result.toTvShowDto(
     genres: List<GenreDto> = emptyList(),
-    userRating: Double? = null,
     numberOfSeasons: Int = 1
 ): TvShowDto {
     return TvShowDto(
@@ -23,7 +22,7 @@ private fun TvShowSearchResponse.Result.toTvShowDto(
         title = this.title.orEmpty(),
         genres = filterGenres(this.genreIds ?: emptyList<Int>(), genres),
         imdbRating = this.voteAverage ?: 0.0,
-        userRating = userRating,
+        userRating = 0,
         releaseDate = this.releaseDate.orEmpty(),
         overview = this.overview.orEmpty(),
         posterPictureURL = this.posterPath?.let { "https://image.tmdb.org/t/p/w500$it" }.orEmpty(),

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/tvShow/PopularTvShowsMapper.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/tvShow/PopularTvShowsMapper.kt
@@ -20,7 +20,7 @@ fun PopularTvShowsResponse.Result.toDto(): TvShowDto {
             )
         } ?: emptyList(),
         imdbRating = voteAverage ?: 0.0,
-        userRating = 0.0,
+        userRating = 0,
         releaseDate = firstAirDate.takeIf { !it.isNullOrEmpty() } ?: "0001-01-01",
         overview = "",
         posterPictureURL = posterPath?.let { "https://image.tmdb.org/t/p/w500$it" } ?: "",

--- a/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/tvShow/TopRatedTvShowSearchResponseMapper.kt
+++ b/remote_datasource/src/main/java/com/baghdad/remoteDataSource/mapper/tvShow/TopRatedTvShowSearchResponseMapper.kt
@@ -17,7 +17,6 @@ fun TopRatedTvShowSearchResponse.toPagedTvShowDtos() = PagedResultDto(
 
 
 private fun TopRatedTvShowSearchResponse.Result.toTvShowDto(
-    userRating: Double? = null,
     numberOfSeasons: Int = 1
 ): TvShowDto {
     val tvShowGenres = this.genreIds?.map { GenreDto(it?.toLong() ?: 0L, "", GenreDto.GenreType.TV_SHOW) } ?: emptyList()
@@ -26,7 +25,7 @@ private fun TopRatedTvShowSearchResponse.Result.toTvShowDto(
         title = this.title.orEmpty(),
         genres = tvShowGenres,
         imdbRating = this.voteAverage ?: 0.0,
-        userRating = userRating,
+        userRating = 0,
         releaseDate = this.releaseDate.orEmpty(),
         overview = this.overview.orEmpty(),
         posterPictureURL = this.posterPath?.let { "https://image.tmdb.org/t/p/w500$it" }.orEmpty(),

--- a/repository/src/main/java/com/baghdad/repository/model/TvShowDto.kt
+++ b/repository/src/main/java/com/baghdad/repository/model/TvShowDto.kt
@@ -6,7 +6,7 @@ data class TvShowDto(
     val title: String,
     val genres: List<GenreDto>,
     val imdbRating: Double,
-    val userRating: Double?,
+    val userRating: Int?,
     val releaseDate: String,
     val overview: String,
     val posterPictureURL: String,

--- a/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/AppLanguageBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/AppLanguageBottomSheet.kt
@@ -59,7 +59,7 @@ fun AppLanguageBottomSheet(
                 onClick = onSaveClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 24.dp)
+                    .padding(bottom = 24.dp, top = 12.dp)
             )
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/AppThemeBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/AppThemeBottomSheet.kt
@@ -60,7 +60,7 @@ fun AppThemeBottomSheet(
                 onClick = onSaveClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 24.dp)
+                    .padding(bottom = 24.dp, top = 12.dp)
             )
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/ContentRestrictionBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/ContentRestrictionBottomSheet.kt
@@ -58,7 +58,7 @@ fun ContentRestrictionBottomSheet(
                 onClick = onSaveClick,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 24.dp)
+                    .padding(bottom = 24.dp, top = 12.dp)
             )
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/RatingBottomSheet.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/component/bottomSheet/RatingBottomSheet.kt
@@ -32,6 +32,7 @@ fun RatingBottomSheet(
     rate: Int,
     onRateChanged: (Int) -> Unit,
     onSubmitClick: () -> Unit,
+    isButtonEnabled: Boolean,
     modifier: Modifier = Modifier
 ) {
 
@@ -72,6 +73,7 @@ fun RatingBottomSheet(
             PrimaryButton(
                 label = stringResource(R.string.submit),
                 onClick = onSubmitClick,
+                isEnabled = isButtonEnabled,
                 modifier = Modifier.fillMaxWidth()
                     .padding(bottom = 24.dp)
             )
@@ -116,6 +118,7 @@ private fun RatingBottomSheetPrev() {
                 rate = 5,
                 onRateChanged = {},
                 onSubmitClick = {},
+                isButtonEnabled = true
             )
         }
     }

--- a/ui/src/main/java/com/baghdad/ui/feature/episodeDetails/EpisodeDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/episodeDetails/EpisodeDetailsScreen.kt
@@ -136,9 +136,10 @@ fun EpisodeDetailsContent(
         RatingBottomSheet(
             isVisible = state.ratingStatus.isBottomSheetVisible && state.ratingStatus.bottomSheetType == BottomSheetType.ShowRating,
             onBottomSheetCloseClick = { listener.onDismissRatingBottomSheet() },
-            rate = state.episode.userRating ?: 0,
+            rate = state.episode.userRating,
+            isButtonEnabled = state.episode.userRating != 0,
             onRateChanged = { listener.onRatingChanged(it) },
-            onSubmitClick = { listener.onClickSubmitRating(state.episode.userRating ?: 0) }
+            onSubmitClick = { listener.onClickSubmitRating(state.episode.userRating) }
         )
 
 

--- a/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
@@ -217,9 +217,10 @@ private fun MovieDetailsContent(
             RatingBottomSheet(
                 isVisible = state.ratingStatus.isBottomSheetVisible,
                 onBottomSheetCloseClick = { listener.onDismissRatingBottomSheet() },
-                rate = state.userRating ?: 0,
+                rate = state.userRating ,
                 onRateChanged = { listener.onRatingChanged(it) },
-                onSubmitClick = { listener.onClickSubmitRating(state.userRating ?: 0) }
+                isButtonEnabled = state.userRating != 0,
+                onSubmitClick = { listener.onClickSubmitRating(state.userRating ) }
             )
 
 

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
@@ -193,9 +193,10 @@ fun TvShowDetailsContent(
             RatingBottomSheet(
                 isVisible = uiState.ratingStatus.isBottomSheetVisible && uiState.ratingStatus.bottomSheetType == BottomSheetType.ShowRating,
                 onBottomSheetCloseClick = { listener.onDismissRatingBottomSheet() },
-                rate = uiState.tvShowInfo.userRating ?: 0,
+                rate = uiState.tvShowInfo.userRating,
+                isButtonEnabled = uiState.tvShowInfo.userRating != 0,
                 onRateChanged = { listener.onRatingChanged(it) },
-                onSubmitClick = { listener.onClickSubmitRating(uiState.tvShowInfo.userRating ?: 0) }
+                onSubmitClick = { listener.onClickSubmitRating(uiState.tvShowInfo.userRating) }
             )
 
             LoginRequiredSheet(

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapper.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsMapper.kt
@@ -16,7 +16,7 @@ fun Episode.toUiState() = EpisodeDetailsScreenState.EpisodeUiState(
     currentSeason = currentSeason,
     overview = overview,
     headerPictures = headerPictures,
-    userRating = userRating?.toInt(),
+    userRating = userRating ?: 0,
     categories = genres.toUiStates(),
 )
 

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenState.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsScreenState.kt
@@ -24,7 +24,7 @@ data class EpisodeDetailsScreenState(
         val episodeNumber: Int = 0,
         val rating: Double = 0.0,
         val trailerUrl: String = "",
-        val userRating: Int? = 0,
+        val userRating: Int = 0,
         val duration: String = "",
         val releasedDate: String = "",
         val currentSeason: Int = 0,

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/episodeDetails/EpisodeDetailsViewModel.kt
@@ -189,8 +189,8 @@ class EpisodeDetailsViewModel @Inject constructor(
             it.copy(
                 ratingStatus = it.ratingStatus.copy(
                     isBottomSheetVisible = false,
-                    bottomSheetType = BottomSheetType.Hidden
-                )
+                ),
+                episode = it.episode.copy(userRating = 0)
             )
         }
     }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsState.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsState.kt
@@ -22,7 +22,7 @@ data class MovieDetailsState(
     val isExtendText: Boolean = false,
     val isSaved: Boolean = false,
     val isHasTrailer: Boolean = true,
-    val userRating: Int? = 0,
+    val userRating: Int = 0,
     val isRated: Boolean = true,
     val ratingStatus: RatingUiState = RatingUiState(),
     ) : BaseUiState {

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/movieDetails/MovieDetailsViewModel.kt
@@ -193,8 +193,8 @@ class MovieDetailsViewModel @Inject constructor(
             it.copy(
                 ratingStatus = it.ratingStatus.copy(
                     isBottomSheetVisible = false,
-                    bottomSheetType = BottomSheetType.Hidden
-                )
+                ),
+                userRating = 0
             )
         }
     }

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsMapper.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsMapper.kt
@@ -18,7 +18,7 @@ fun TvShow.toUiState() =
         seasonCount = numberOfSeasons,
         overView = overview,
         trailerURL = trailerURL,
-        userRating = userRating?.toInt(),
+        userRating = userRating ?: 0,
         posterPictureURL = posterImageURL,
         headerImagesURLs = headerImagesURLs,
     )

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsScreenState.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsScreenState.kt
@@ -27,7 +27,7 @@ data class TvShowDetailsScreenState(
         val overView: String = "",
         val trailerURL: String = "",
         val posterPictureURL: String = "",
-        val userRating: Int? = 0,
+        val userRating: Int = 0,
         val headerImagesURLs: List<String> = emptyList()
     )
 

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/tvShowDetails/TvShowDetailsViewModel.kt
@@ -176,8 +176,8 @@ class TvShowDetailsViewModel @Inject constructor(
             it.copy(
                 ratingStatus = it.ratingStatus.copy(
                     isBottomSheetVisible = false,
-                    bottomSheetType = BottomSheetType.Hidden
-                )
+                ),
+                tvShowInfo = it.tvShowInfo.copy(userRating = 0)
             )
         }
     }


### PR DESCRIPTION
Make the submit button enabled only when user starts rating an item


https://github.com/user-attachments/assets/002ea2a5-e7e4-4168-9058-2dd66ad699b1

