### PR TITLE
Fix/#767 profile screens bottomsheets doesn't get dismissed after user clicks-save

### DIFF
--- a/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/actorDetails/ActorDetailsScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -53,6 +54,7 @@ import com.baghdad.viewmodel.actorDetails.ActorDetailsViewModel
 import com.baghdad.viewmodel.base.SnackBarState
 import com.baghdad.viewmodel.errorStates.BaseSnackBarMessage
 import com.baghdad.viewmodel.shared.SavedListUiState
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 
 @Composable
@@ -127,6 +129,14 @@ fun ActorDetailsContent(
 ) {
     val scrollState = rememberScrollState()
     var shouldShowBackground by remember { mutableStateOf(false) }
+
+    val systemUiController = rememberSystemUiController()
+    LaunchedEffect(Unit) {
+        systemUiController.setStatusBarColor(
+            color = Color.Transparent,
+            darkIcons = false
+        )
+    }
 
     val animatedColor by animateColorAsState(
         targetValue =

--- a/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/movieDetails/MovieDetailsScreen.kt
@@ -195,7 +195,7 @@ private fun MovieDetailsContent(
 
     val systemUiController = rememberSystemUiController()
     LaunchedEffect(Unit) {
-        systemUiController.setSystemBarsColor(
+        systemUiController.setStatusBarColor(
             color = Color.Transparent,
             darkIcons = false
         )

--- a/ui/src/main/java/com/baghdad/ui/feature/onBoarding/OnBoardingScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/onBoarding/OnBoardingScreen.kt
@@ -78,7 +78,7 @@ private fun OnBoardingContent(
     val systemUiController = rememberSystemUiController()
 
     LaunchedEffect(Unit) {
-        systemUiController.setSystemBarsColor(
+        systemUiController.setStatusBarColor(
             color = Color.Transparent,
             darkIcons = false
         )

--- a/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/tvShowDetails/TvShowDetailsScreen.kt
@@ -165,7 +165,7 @@ fun TvShowDetailsContent(
 
     val systemUiController = rememberSystemUiController()
     LaunchedEffect(Unit) {
-        systemUiController.setSystemBarsColor(
+        systemUiController.setStatusBarColor(
             color = Color.Transparent,
             darkIcons = false
         )

--- a/ui/src/main/java/com/baghdad/ui/feature/welcome/WelcomeScreen.kt
+++ b/ui/src/main/java/com/baghdad/ui/feature/welcome/WelcomeScreen.kt
@@ -65,7 +65,7 @@ private fun WelcomeScreenContent(
     val systemUiController = rememberSystemUiController()
 
     LaunchedEffect(Unit) {
-        systemUiController.setSystemBarsColor(
+        systemUiController.setStatusBarColor(
             color = Color.Transparent,
             darkIcons = false
         )

--- a/viewmodel/src/main/java/com/baghdad/viewmodel/profile/ProfileViewModel.kt
+++ b/viewmodel/src/main/java/com/baghdad/viewmodel/profile/ProfileViewModel.kt
@@ -170,16 +170,34 @@ class ProfileViewModel @Inject constructor(
     override fun onAppearanceConfirmed() {
         tryToExecute(
             callee = { setAppThemeUseCase(currentState.themeBottomSheetState.currentTheme.isDark) },
+            onSuccess = {onAppearanceConfirmedSuccess()},
             dispatcher = ioDispatcher
         )
+    }
+
+    private fun onAppearanceConfirmedSuccess() {
+        updateState {
+            it.copy(
+                themeBottomSheetState = it.themeBottomSheetState.copy(isVisible = false)
+            )
+        }
     }
 
 
     override fun onLanguageConfirmed() {
         tryToExecute(
             callee = { setAppLanguageUseCase(currentState.languageBottomSheetState.currentLanguage.languageCode) },
+            onSuccess = { onLanguageConfirmedSuccess() },
             dispatcher = ioDispatcher,
         )
+    }
+
+    private fun onLanguageConfirmedSuccess() {
+        updateState {
+            it.copy(
+                languageBottomSheetState = it.languageBottomSheetState.copy(isVisible = false)
+            )
+        }
     }
 
 


### PR DESCRIPTION
- Make the bottom sheets in the profile screen get dismissed when the user saves their selection.
- Fixed the gray system navigation bar padding by changing only the status bars colors to transparent for required screens